### PR TITLE
fix: Stash pop removes stash from list even when there are conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * add `use_selection_fg` to theme file to allow customizing selection foreground color [[@Upsylonbare](https://github.com/Upsylonbare)] ([#2515](https://github.com/gitui-org/gitui/pull/2515))
 
 ### Changed
+* Stash pop removes stash from list even when there are conflicts([#2372](https://github.com/extrawurst/gitui/issues/2372))
 * improve syntax highlighting file detection [[@acuteenvy](https://github.com/acuteenvy)] ([#2524](https://github.com/extrawurst/gitui/pull/2524))
 * Updated project links to point to `gitui-org` instead of `extrawurst`  [[@vasleymus](https://github.com/vasleymus)] ([#2538](https://github.com/gitui-org/gitui/pull/2538))
 * After commit: jump back to unstaged area [[@tommady](https://github.com/tommady)] ([#2476](https://github.com/extrawurst/gitui/issues/2476))

--- a/asyncgit/src/error.rs
+++ b/asyncgit/src/error.rs
@@ -22,6 +22,10 @@ pub enum Error {
 	RebaseConflict,
 
 	///
+	#[error("git: conflict during stash apply")]
+	StashApplyConflict,
+
+	///
 	#[error("git: remote url not found")]
 	UnknownRemote,
 


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #2372 .

It changes the following:
- `stash_pop` not remove stash from list even when there are conflicts

before change
[before1005.webm](https://github.com/user-attachments/assets/fe0ae937-bdd0-4fb3-b266-6e89a458586f)

after change
[after1005.webm](https://github.com/user-attachments/assets/89c6f304-af9e-4dbb-a83e-ce5fc0145198)


stash pop success
[success1005.webm](https://github.com/user-attachments/assets/dd0159d6-9e3c-450f-b057-6b0efc81a24e)


I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog