### PR TITLE
feat(ui): Add use_selection_fg flag to control selection foreground color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Select syntax highlighting theme out of the defaults from syntect [[@vasilismanol](https://github.com/vasilismanol)] ([#1931](https://github.com/extrawurst/gitui/issues/1931))
 * new command-line option to override the default log file path (`--logfile`) [[@acuteenvy](https://github.com/acuteenvy)] ([#2539](https://github.com/gitui-org/gitui/pull/2539))
 * dx: `make check` checks Cargo.toml dependency ordering using `cargo sort` [[@naseschwarz](https://github.com/naseschwarz)]
+* add `use_selection_fg` to theme file to allow customizing selection foreground color [[@Upsylonbare](https://github.com/Upsylonbare)] ([#2515](https://github.com/gitui-org/gitui/pull/2515))
 
 ### Changed
 * improve syntax highlighting file detection [[@acuteenvy](https://github.com/acuteenvy)] ([#2524](https://github.com/extrawurst/gitui/pull/2524))

--- a/THEMES.md
+++ b/THEMES.md
@@ -49,3 +49,16 @@ Note that if you want to turn it off, you should use a blank string:
     line_break: Some(""),
 )
 ```
+## Customizing selection
+
+By default the `selection_fg` color is used to color the text of the selected line.
+Diff line, filename, commit hashes, time and author are re-colored with `selection_fg` color.
+This can be changed by specifying the `use_selection_fg` boolean in your `theme.ron`:
+
+```
+(
+    use_selection_fg: Some(false),
+)
+```
+
+By default, `use_selection_fg` is set to `true`.

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -16,6 +16,7 @@ pub struct Theme {
 	command_fg: Color,
 	selection_bg: Color,
 	selection_fg: Color,
+	use_selection_fg: bool,
 	cmdbar_bg: Color,
 	cmdbar_extra_lines_bg: Color,
 	disabled_fg: Color,
@@ -151,7 +152,11 @@ impl Theme {
 		selected: bool,
 	) -> Style {
 		if selected {
-			style.bg(self.selection_bg).fg(self.selection_fg)
+			if self.use_selection_fg {
+				style.bg(self.selection_bg).fg(self.selection_fg)
+			} else {
+				style.bg(self.selection_bg)
+			}
 		} else {
 			style
 		}
@@ -340,6 +345,7 @@ impl Default for Theme {
 			command_fg: Color::White,
 			selection_bg: Color::Blue,
 			selection_fg: Color::White,
+			use_selection_fg: true,
 			cmdbar_bg: Color::Blue,
 			cmdbar_extra_lines_bg: Color::Blue,
 			disabled_fg: Color::DarkGray,
@@ -387,6 +393,7 @@ mod tests {
 (
 	selection_bg: Some("Black"),
 	selection_fg: Some("#ffffff"),
+	use_selection_fg: Some(false),
 	syntax: Some("InspiredGitHub")
 )
 "##


### PR DESCRIPTION
When set to `False` (default `True`), keep the foreground color of the selected object (commit hash, date, etc ...).

It changes the following:  
- Added a new `use_selection_fg` flag to the `Theme` struct, allowing users to toggle whether the selection foreground color is applied.  
- Set `use_selection_fg` to `true` by default in `Theme::Default`.  
- Extended unit tests to validate the behavior of `use_selection_fg`.  

I followed the checklist:  
- [x] I added unittests  
- [x] I ran `make check` without errors  
- [x] I tested the overall application  
- [ ] I added an appropriate item to the changelog  