### PR TITLE
Add `--logfile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+* new command-line options: `-f` and `--logfile` to override the default log file path [[@acuteenvy](https://github.com/acuteenvy)] ([#2539](https://github.com/gitui-org/gitui/pull/2539))
+
 ### Changed
 * improve syntax highlighting file detection [[@acuteenvy](https://github.com/acuteenvy)] ([#2524](https://github.com/extrawurst/gitui/pull/2524))
 * After commit: jump back to unstaged area [[@tommady](https://github.com/tommady)] ([#2476](https://github.com/extrawurst/gitui/issues/2476))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-* new command-line options: `-f` and `--logfile` to override the default log file path [[@acuteenvy](https://github.com/acuteenvy)] ([#2539](https://github.com/gitui-org/gitui/pull/2539))
+* new command-line option to override the default log file path (`--logfile`) [[@acuteenvy](https://github.com/acuteenvy)] ([#2539](https://github.com/gitui-org/gitui/pull/2539))
 
 ### Changed
 * improve syntax highlighting file detection [[@acuteenvy](https://github.com/acuteenvy)] ([#2524](https://github.com/extrawurst/gitui/pull/2524))

--- a/src/args.rs
+++ b/src/args.rs
@@ -2,8 +2,8 @@ use crate::bug_report;
 use anyhow::{anyhow, Result};
 use asyncgit::sync::RepoPath;
 use clap::{
-	crate_authors, crate_description, crate_name, Arg,
-	Command as ClapApp,
+	builder::ArgPredicate, crate_authors, crate_description,
+	crate_name, Arg, Command as ClapApp,
 };
 use simplelog::{Config, LevelFilter, WriteLogger};
 use std::{
@@ -28,7 +28,8 @@ pub fn process_cmdline() -> Result<CliArgs> {
 		std::process::exit(0);
 	}
 	if arg_matches.get_flag("logging") {
-		setup_logging()?;
+		let logfile = arg_matches.get_one::<String>("logfile");
+		setup_logging(logfile.map(PathBuf::from))?;
 	}
 
 	let workdir =
@@ -87,11 +88,17 @@ fn app() -> ClapApp {
 		)
 		.arg(
 			Arg::new("logging")
-				.help("Stores logging output into a cache directory")
+				.help("Store logging output into a file (in the cache directory by default)")
 				.short('l')
 				.long("logging")
-				.num_args(0),
+                .default_value_if("logfile", ArgPredicate::IsPresent, "true")
+				.action(clap::ArgAction::SetTrue),
 		)
+        .arg(Arg::new("logfile")
+            .help("Store logging output into the specified file (implies --logging)")
+            .short('f')
+            .long("logfile")
+            .value_name("LOG_FILE"))
 		.arg(
 			Arg::new("watcher")
 				.help("Use notify-based file system watcher instead of tick-based update. This is more performant, but can cause issues on some platforms. See https://github.com/extrawurst/gitui/blob/master/FAQ.md#watcher for details.")
@@ -122,11 +129,16 @@ fn app() -> ClapApp {
 		)
 }
 
-fn setup_logging() -> Result<()> {
-	let mut path = get_app_cache_path()?;
-	path.push("gitui.log");
+fn setup_logging(path_override: Option<PathBuf>) -> Result<()> {
+	let path = if let Some(path) = path_override {
+		path
+	} else {
+		let mut path = get_app_cache_path()?;
+		path.push("gitui.log");
+		path
+	};
 
-	println!("Logging enabled. log written to: {path:?}");
+	println!("Logging enabled. Log written to: {path:?}");
 
 	WriteLogger::init(
 		LevelFilter::Trace,

--- a/src/args.rs
+++ b/src/args.rs
@@ -96,7 +96,6 @@ fn app() -> ClapApp {
 		)
         .arg(Arg::new("logfile")
             .help("Store logging output into the specified file (implies --logging)")
-            .short('f')
             .long("logfile")
             .value_name("LOG_FILE"))
 		.arg(


### PR DESCRIPTION
Add a command-line option to override the default log file path.

`gitui --logging` stays unchanged;
`gitui --logfile path/to/file.log` logs to `path/to/file.log`;
`gitui --logging --logfile path/to/file.log` is equivalent to using just `--logfile`.

This Pull Request fixes/closes #2528.

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog