### PR TITLE
Push with refspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * After commit: jump back to unstaged area [[@tommady](https://github.com/tommady)] ([#2476](https://github.com/extrawurst/gitui/issues/2476))
 * The default key to close the commit error message popup is now the Escape key [[@wessamfathi](https://github.com/wessamfathi)] ([#2552](https://github.com/extrawurst/gitui/issues/2552))
 * use OSC52 copying in case other methods fail [[@naseschwarz](https://github.com/naseschwarz)] ([#2366](https://github.com/gitui-org/gitui/issues/2366))
+* push: respect `branch.*.merge` when push default is upstream [[@vlad-anger](https://github.com/vlad-anger)] ([#2542](https://github.com/gitui-org/gitui/pull/2542))
 
 ## [0.27.0] - 2024-01-14
 

--- a/asyncgit/src/error.rs
+++ b/asyncgit/src/error.rs
@@ -54,6 +54,10 @@ pub enum Error {
 	Git(#[from] git2::Error),
 
 	///
+	#[error("git config error: {0}")]
+	GitConfig(String),
+
+	///
 	#[error("strip prefix error: {0}")]
 	StripPrefix(#[from] StripPrefixError),
 

--- a/asyncgit/src/sync/branch/mod.rs
+++ b/asyncgit/src/sync/branch/mod.rs
@@ -245,7 +245,7 @@ pub fn get_branch_remote(
 
 /// Retrieve the upstream merge of a local `branch`,
 /// configured in "branch.*.merge"
-/// 
+///
 /// For details check git2 `branch_upstream_merge`
 pub fn get_branch_upstream_merge(
 	repo_path: &RepoPath,

--- a/asyncgit/src/sync/branch/mod.rs
+++ b/asyncgit/src/sync/branch/mod.rs
@@ -243,6 +243,25 @@ pub fn get_branch_remote(
 	}
 }
 
+/// Retrieve the upstream merge of a local `branch`,
+/// configured in "branch.*.merge"
+/// 
+/// For details check git2 `branch_upstream_merge`
+pub fn get_branch_upstream_merge(
+	repo_path: &RepoPath,
+	branch: &str,
+) -> Result<Option<String>> {
+	let repo = repo(repo_path)?;
+	let branch = repo.find_branch(branch, BranchType::Local)?;
+	let reference = bytes2string(branch.get().name_bytes())?;
+	let remote_name = repo.branch_upstream_merge(&reference).ok();
+	if let Some(remote_name) = remote_name {
+		Ok(Some(bytes2string(remote_name.as_ref())?))
+	} else {
+		Ok(None)
+	}
+}
+
 /// returns whether the pull merge strategy is set to rebase
 pub fn config_is_pull_rebase(repo_path: &RepoPath) -> Result<bool> {
 	let repo = repo(repo_path)?;
@@ -672,6 +691,49 @@ mod tests_branches {
 			&root.as_os_str().to_str().unwrap().into();
 
 		assert!(get_branch_remote(repo_path, "foo").is_err());
+	}
+
+	#[test]
+	fn test_branch_no_upstream_merge_config() {
+		let (_r, repo) = repo_init().unwrap();
+		let root = repo.path().parent().unwrap();
+		let repo_path: &RepoPath =
+			&root.as_os_str().to_str().unwrap().into();
+
+		let upstream_merge_res =
+			get_branch_upstream_merge(&repo_path, "master");
+		assert!(
+			upstream_merge_res.is_ok_and(|v| v.as_ref().is_none())
+		);
+	}
+
+	#[test]
+	fn test_branch_with_upstream_merge_config() {
+		let (_r, repo) = repo_init().unwrap();
+		let root = repo.path().parent().unwrap();
+		let repo_path: &RepoPath =
+			&root.as_os_str().to_str().unwrap().into();
+
+		let branch_name = "master";
+		let upstrem_merge = "refs/heads/master";
+
+		let mut config = repo.config().unwrap();
+		config
+			.set_str(
+				&format!("branch.{branch_name}.merge"),
+				&upstrem_merge,
+			)
+			.expect("fail set branch merge config");
+
+		let upstream_merge_res =
+			get_branch_upstream_merge(&repo_path, &branch_name);
+		assert!(upstream_merge_res
+			.as_ref()
+			.is_ok_and(|v| v.as_ref().is_some()));
+		assert_eq!(
+			&upstream_merge_res.unwrap().unwrap(),
+			upstrem_merge
+		);
 	}
 }
 

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -39,7 +39,7 @@ pub use blame::{blame_file, BlameHunk, FileBlame};
 pub use branch::{
 	branch_compare_upstream, checkout_branch, checkout_commit,
 	config_is_pull_rebase, create_branch, delete_branch,
-	get_branch_remote, get_branches_info,
+	get_branch_remote, get_branches_info, get_branch_upstream_merge,
 	merge_commit::merge_upstream_commit,
 	merge_ff::branch_merge_upstream_fastforward,
 	merge_rebase::merge_upstream_rebase, rename::rename_branch,

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -39,7 +39,7 @@ pub use blame::{blame_file, BlameHunk, FileBlame};
 pub use branch::{
 	branch_compare_upstream, checkout_branch, checkout_commit,
 	config_is_pull_rebase, create_branch, delete_branch,
-	get_branch_remote, get_branches_info, get_branch_upstream_merge,
+	get_branch_remote, get_branch_upstream_merge, get_branches_info,
 	merge_commit::merge_upstream_commit,
 	merge_ff::branch_merge_upstream_fastforward,
 	merge_rebase::merge_upstream_rebase, rename::rename_branch,


### PR DESCRIPTION
Fixes #2537

git2 merged [necessary PR](https://github.com/rust-lang/git2-rs/pull/1131)

This PR _is_blocked_ until new version git2 lib released
For now use git2 from master to be able to test PR.

---

Assume git config:
```git-config
[branch "oblava"]
	remote = origin
	merge = refs/heads/master
[push]
  default = upstream
```
Prev. behavior:
push -> push oblava -> remote oblava <- new remote created

New behavior:
push -> push oblava -> remote master

---

I followed the checklist:
- [x] I added unittests
- [x] I ran `make check` without errors (see commit with tests fixes)
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog