### PR TITLE
Copy text using OSC52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * improve syntax highlighting file detection [[@acuteenvy](https://github.com/acuteenvy)] ([#2524](https://github.com/extrawurst/gitui/pull/2524))
 * After commit: jump back to unstaged area [[@tommady](https://github.com/tommady)] ([#2476](https://github.com/extrawurst/gitui/issues/2476))
+* use OSC52 copying in case other methods fail [[@naseschwarz](https://github.com/naseschwarz)] ([#2366](https://github.com/gitui-org/gitui/issues/2366))
 
 ## [0.27.0] - 2024-01-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,6 +1162,7 @@ dependencies = [
  "anyhow",
  "asyncgit",
  "backtrace",
+ "base64",
  "bitflags 2.8.0",
  "bugreport",
  "bwrap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ build = "build.rs"
 anyhow = "1.0"
 asyncgit = { path = "./asyncgit", version = "0.27.0", default-features = false }
 backtrace = "0.3"
+base64 = "0.21"
 bitflags = "2.8"
 bugreport = "0.5.1"
 bwrap = { version = "1.3", features = ["use_std"] }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, Result};
-use base64::prelude::{Engine, BASE64_STANDARD};
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -68,7 +67,12 @@ fn is_wsl() -> bool {
 // This enables copying even if there is no Wayland or X socket available,
 // e.g. via SSH, as long as it supported by the terminal.
 // See https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands
+#[cfg(any(
+	all(target_family = "unix", not(target_os = "macos")),
+	test
+))]
 fn copy_string_osc52(text: &str, out: &mut impl Write) -> Result<()> {
+	use base64::prelude::{Engine, BASE64_STANDARD};
 	const OSC52_DESTINATION_CLIPBOARD: char = 'c';
 	write!(
 		out,
@@ -80,33 +84,47 @@ fn copy_string_osc52(text: &str, out: &mut impl Write) -> Result<()> {
 }
 
 #[cfg(all(target_family = "unix", not(target_os = "macos")))]
-pub fn copy_string(text: &str) -> Result<()> {
-	if std::env::var("WAYLAND_DISPLAY").is_ok() {
-		if exec_copy_with_args("wl-copy", &[], text, false).is_err() {
-			copy_string_osc52(text, &mut std::io::stdout())?;
-		}
+fn copy_string_wayland(text: &str) -> Result<()> {
+	if exec_copy_with_args("wl-copy", &[], text, false).is_ok() {
+		return Ok(());
 	}
 
-	if is_wsl() {
-		return exec_copy_with_args("clip.exe", &[], text, false);
-	}
+	copy_string_osc52(text, &mut std::io::stdout())
+}
 
+#[cfg(all(target_family = "unix", not(target_os = "macos")))]
+fn copy_string_x(text: &str) -> Result<()> {
 	if exec_copy_with_args(
 		"xclip",
 		&["-selection", "clipboard"],
 		text,
 		false,
 	)
-	.is_err()
+	.is_ok()
 	{
-		if exec_copy_with_args("xsel", &["--clipboard"], text, true)
-			.is_err()
-		{
-			copy_string_osc52(text, &mut std::io::stdout())?;
-		}
+		return Ok(());
 	}
 
-	Ok(())
+	if exec_copy_with_args("xsel", &["--clipboard"], text, true)
+		.is_ok()
+	{
+		return Ok(());
+	}
+
+	copy_string_osc52(text, &mut std::io::stdout())
+}
+
+#[cfg(all(target_family = "unix", not(target_os = "macos")))]
+pub fn copy_string(text: &str) -> Result<()> {
+	if std::env::var("WAYLAND_DISPLAY").is_ok() {
+		return copy_string_wayland(text);
+	}
+
+	if is_wsl() {
+		return exec_copy_with_args("clip.exe", &[], text, false);
+	}
+
+	copy_string_x(text)
 }
 
 #[cfg(any(target_os = "macos", windows))]


### PR DESCRIPTION
This Pull Request closes #2366.

It changes the following:
- If copying using wl-clip or xclip and xsel fails, copy using [OSC52](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands) (Search for "Ps = 5 2").

This does not change the default behavior. On both wayland and X, wl-copy and xclip/xsel will be preferred. Only if one path fails, an OSC52 escape sequence will be issued.

I have tested this by running tmux, which has the option to turn support for this off and on (using `:set -g set-clipboard off` or `:set -g set-clipboard on`) and SSH. When tmux's clipboard support was off, no text was copied. Once I enabled it, copying worked as expected. From this I conclude that the whole setup works as expected.

N.B.: There is no easy path for gitui itself to check whether copying worked. Also, this essentially **disables error reporting on wl-clip, xclip and xsel**, as it acts as a fallback for these options.

I followed the checklist:
- [x] I added unittests
- [ ] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog