### PR TITLE
Dismiss commit msg key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * improve syntax highlighting file detection [[@acuteenvy](https://github.com/acuteenvy)] ([#2524](https://github.com/extrawurst/gitui/pull/2524))
 * After commit: jump back to unstaged area [[@tommady](https://github.com/tommady)] ([#2476](https://github.com/extrawurst/gitui/issues/2476))
+* The default key to close the commit error message popup is now the Escape key [[@wessamfathi](https://github.com/wessamfathi)] ([#2552](https://github.com/extrawurst/gitui/issues/2552))
 
 ## [0.27.0] - 2024-01-14
 

--- a/src/popups/msg.rs
+++ b/src/popups/msg.rs
@@ -135,7 +135,7 @@ impl Component for MsgPopup {
 	fn event(&mut self, ev: &Event) -> Result<EventState> {
 		if self.visible {
 			if let Event::Key(e) = ev {
-				if key_match(e, self.key_config.keys.enter) {
+				if key_match(e, self.key_config.keys.exit_popup) {
 					self.hide();
 				} else if key_match(
 					e,

--- a/src/popups/msg.rs
+++ b/src/popups/msg.rs
@@ -114,7 +114,7 @@ impl Component for MsgPopup {
 		_force_all: bool,
 	) -> CommandBlocking {
 		out.push(CommandInfo::new(
-			strings::commands::close_msg(&self.key_config),
+			strings::commands::close_popup(&self.key_config),
 			true,
 			self.visible,
 		));


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #2552.

It changes the following:
- The default key to close the commit error message popup is now the Escape key

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog