### PR TITLE
Support loading custom syntax themes from a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+* support loading custom syntax highlighting themes from a file [[@acuteenvy](https://github.com/acuteenvy)] ([#2565](https://github.com/gitui-org/gitui/pull/2565))
 * Select syntax highlighting theme out of the defaults from syntect [[@vasilismanol](https://github.com/vasilismanol)] ([#1931](https://github.com/extrawurst/gitui/issues/1931))
 * new command-line option to override the default log file path (`--logfile`) [[@acuteenvy](https://github.com/acuteenvy)] ([#2539](https://github.com/gitui-org/gitui/pull/2539))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,7 +1168,7 @@ dependencies = [
  "anyhow",
  "asyncgit",
  "backtrace",
- "base64",
+ "base64 0.21.7",
  "bitflags 2.9.0",
  "bugreport",
  "bwrap",
@@ -2658,6 +2664,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
+name = "plist"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,6 +2765,15 @@ checksum = "a266d8d6020c61a437be704c5e618037588e1985c7dbb7bf8d265db84cffe325"
 dependencies = [
  "log",
  "parking_lot",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2893,7 +2921,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bitflags 2.9.0",
  "serde",
  "serde_derive",
@@ -3378,6 +3406,7 @@ dependencies = [
  "fnv",
  "once_cell",
  "onig",
+ "plist",
  "regex-syntax",
  "serde",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,12 +224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,7 +1162,7 @@ dependencies = [
  "anyhow",
  "asyncgit",
  "backtrace",
- "base64 0.21.7",
+ "base64",
  "bitflags 2.9.0",
  "bugreport",
  "bwrap",
@@ -2669,7 +2663,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "indexmap",
  "quick-xml",
  "serde",
@@ -2921,7 +2915,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63f3aa105dea217ef30d89581b65a4d527a19afc95ef5750be3890e8d3c5b837"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "bitflags 2.9.0",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ syntect = { version = "5.2", default-features = false, features = [
     "parsing",
     "default-syntaxes",
     "default-themes",
+    "plist-load",
     "html",
 ] }
 tui-textarea = "0.7"

--- a/src/args.rs
+++ b/src/args.rs
@@ -49,7 +49,9 @@ pub fn process_cmdline() -> Result<CliArgs> {
 		.get_one::<String>("theme")
 		.map_or_else(|| PathBuf::from("theme.ron"), PathBuf::from);
 
-	let theme = get_app_config_path()?.join(arg_theme);
+	let confpath = get_app_config_path()?;
+	fs::create_dir_all(&confpath)?;
+	let theme = confpath.join(arg_theme);
 
 	let notify_watcher: bool =
 		*arg_matches.get_one("watcher").unwrap_or(&false);
@@ -166,7 +168,6 @@ pub fn get_app_config_path() -> Result<PathBuf> {
 	.ok_or_else(|| anyhow!("failed to find os config dir."))?;
 
 	path.push("gitui");
-	fs::create_dir_all(&path)?;
 	Ok(path)
 }
 

--- a/src/keys/key_config.rs
+++ b/src/keys/key_config.rs
@@ -136,6 +136,7 @@ mod tests {
 	#[test]
 	fn test_symbolic_links() {
 		let app_home = get_app_config_path().unwrap();
+		fs::create_dir_all(&app_home).unwrap();
 		// save current config
 		let original_key_list_path = app_home.join(KEY_LIST_FILENAME);
 		let renamed_key_list = if original_key_list_path.exists() {

--- a/src/ui/syntax_text.rs
+++ b/src/ui/syntax_text.rs
@@ -90,14 +90,15 @@ impl SyntaxText {
 		};
 
 		let theme = THEME.get_or_try_init(|| -> Result<Theme, asyncgit::Error> {
-			let mut theme_set = ThemeSet::load_defaults();
 			let theme_path = crate::args::get_app_config_path()
-				.map_err(|e| asyncgit::Error::Generic(e.to_string()))?;
+				.map_err(|e| asyncgit::Error::Generic(e.to_string()))?.join(format!("{syntax}.tmTheme"));
 
-			if let Err(e) = theme_set.add_from_folder(&theme_path) {
-			    log::error!("could not load themes from the config directory: {e}. Only the default set is available");
+			match ThemeSet::get_theme(&theme_path) {
+				Ok(t) => return Ok(t),
+			    Err(e) => log::info!("could not load '{}': {e}, trying from the set of default themes", theme_path.display()),
 			}
 			
+			let mut theme_set = ThemeSet::load_defaults();
 			if let Some(t) = theme_set.themes.remove(syntax) {
 			    return Ok(t);
 			}

--- a/src/ui/syntax_text.rs
+++ b/src/ui/syntax_text.rs
@@ -35,7 +35,6 @@ pub struct SyntaxText {
 
 static SYNTAX_SET: Lazy<SyntaxSet> =
 	Lazy::new(two_face::syntax::extra_no_newlines);
-static THEME_SET: Lazy<ThemeSet> = Lazy::new(ThemeSet::load_defaults);
 static THEME: OnceCell<Theme> = OnceCell::new();
 
 pub struct AsyncProgressBuffer {
@@ -104,12 +103,13 @@ impl SyntaxText {
 					    theme_path.display()
 				    );
 
-				    let t = THEME_SET.themes.get(syntax).unwrap_or_else(|| {
+					let mut default_set = ThemeSet::load_defaults();
+				    let t = default_set.themes.remove(syntax).unwrap_or_else(|| {
 				        log::error!("The syntax theme '{syntax}' cannot be found. Using default theme ('{DEFAULT_SYNTAX_THEME}') instead.");
-				        &THEME_SET.themes[DEFAULT_SYNTAX_THEME]
+				        default_set.themes.remove(DEFAULT_SYNTAX_THEME).expect("the default theme should be there")
 			        });
 
-                    Ok(t.clone())
+                    Ok(t)
                 }
 			}
 		})?;

--- a/src/ui/syntax_text.rs
+++ b/src/ui/syntax_text.rs
@@ -97,7 +97,7 @@ impl SyntaxText {
 				Ok(t) => return Ok(t),
 			    Err(e) => log::info!("could not load '{}': {e}, trying from the set of default themes", theme_path.display()),
 			}
-			
+
 			let mut theme_set = ThemeSet::load_defaults();
 			if let Some(t) = theme_set.themes.remove(syntax) {
 			    return Ok(t);


### PR DESCRIPTION
This Pull Request fixes/closes #2523 & closes #2308.

Custom syntax highlighting themes can be loaded from a `.tmTheme` file.

If `syntax` in `theme.ron` (added in #2532) is a filename that exists in the gitui config directory, it's used as the syntax theme. If not, gitui falls back to selecting from the default theme set.

---

For example, if you put the following in `theme.ron`:
```
(
    syntax: Some("mytheme"),
)
```
gitui will load `~/.config/gitui/mytheme.tmTheme`.

---

I followed the checklist:
- [ ] I added unittests
- [ ] I ran `make check` without errors
  `make check` reports a duplicate dependency error:
   ```
   error[duplicate]: found 2 duplicate entries for crate 'base64'
   ```
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog


