### PR TITLE
Update ron to 0.9, base64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,7 +1168,7 @@ dependencies = [
  "anyhow",
  "asyncgit",
  "backtrace",
- "base64",
+ "base64 0.21.7",
  "bitflags 2.9.0",
  "bugreport",
  "bwrap",
@@ -2889,14 +2895,15 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+checksum = "63f3aa105dea217ef30d89581b65a4d527a19afc95ef5750be3890e8d3c5b837"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bitflags 2.9.0",
  "serde",
  "serde_derive",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,12 +219,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1168,7 +1162,7 @@ dependencies = [
  "anyhow",
  "asyncgit",
  "backtrace",
- "base64 0.21.7",
+ "base64",
  "bitflags 2.9.0",
  "bugreport",
  "bwrap",
@@ -2899,7 +2893,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63f3aa105dea217ef30d89581b65a4d527a19afc95ef5750be3890e8d3c5b837"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bitflags 2.9.0",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ ratatui = { version = "0.29", default-features = false, features = [
     'serde',
 ] }
 rayon-core = "1.12"
-ron = "0.8"
+ron = "0.9"
 scopeguard = "1.2"
 scopetime = { path = "./scopetime", version = "0.1" }
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ build = "build.rs"
 anyhow = "1.0"
 asyncgit = { path = "./asyncgit", version = "0.27.0", default-features = false }
 backtrace = "0.3"
-base64 = "0.21"
+base64 = "0.22"
 bitflags = "2.9"
 bugreport = "0.5.1"
 bwrap = { version = "1.3", features = ["use_std"] }


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #{issue_num}.

It changes the following:
- update ron
  - [Release notes](https://github.com/ron-rs/ron/releases)
  - [Changelog](https://github.com/ron-rs/ron/blob/master/CHANGELOG.md)
  - [Commits](https://github.com/ron-rs/ron/compare/v0.8.1...v0.9.0)
- and base64
  - [Changelog](https://github.com/marshallpierce/rust-base64/blob/master/RELEASE-NOTES.md)
  - [Commits](https://github.com/marshallpierce/rust-base64/compare/v0.21.7...v0.22.1)

This avoids a duplicate dependency on base64 with #2565.

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog