### PR TITLE
Resolve core.hooksPath relative to GIT_WORK_TREE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * set the terminal title to `gitui ({repo_path})` [[@acuteenvy](https://github.com/acuteenvy)] ([#2462](https://github.com/gitui-org/gitui/issues/2462))
 * respect `.mailmap` [[@acuteenvy](https://github.com/acuteenvy)] ([#2406](https://github.com/gitui-org/gitui/issues/2406))
 
+### Fixes
+*  Resolve `core.hooksPath` relative to `GIT_WORK_TREE` [[@naseschwarz](https://github.com/naseschwarz)] ([#2571](https://github.com/gitui-org/gitui/issues/2571))
+
 ## [0.27.0] - 2024-01-14
 
 **new: manage remotes**

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -76,6 +76,23 @@ pub fn hooks_prepare_commit_msg(
 mod tests {
 	use super::*;
 	use crate::sync::tests::repo_init;
+	use std::fs::File;
+	use std::io::Write;
+	use std::path::Path;
+
+	fn create_hook_in_path(path: &Path, hook_script: &[u8]) {
+		File::create(path).unwrap().write_all(hook_script).unwrap();
+
+		#[cfg(unix)]
+		{
+			std::process::Command::new("chmod")
+				.arg("+x")
+				.arg(path)
+				// .current_dir(path)
+				.output()
+				.unwrap();
+		}
+	}
 
 	#[test]
 	fn test_post_commit_hook_reject_in_subfolder() {
@@ -167,6 +184,39 @@ mod tests {
 		)
 		.unwrap();
 
+		assert_eq!(
+			res,
+			HookResult::NotOk(String::from("rejected\n"))
+		);
+
+		assert_eq!(msg, String::from("msg\n"));
+	}
+
+	#[test]
+	fn test_hooks_commit_msg_reject_in_hooks_folder_githooks_moved_absolute(
+	) {
+		let (_td, repo) = repo_init().unwrap();
+		let root = repo.path().parent().unwrap();
+		let mut config = repo.config().unwrap();
+
+		const HOOKS_DIR: &'static str = "my_hooks";
+		config.set_str("core.hooksPath", HOOKS_DIR).unwrap();
+
+		let hook = b"#!/bin/sh
+	echo 'msg' > \"$1\"
+	echo 'rejected'
+	exit 1
+	        ";
+		let hooks_folder = root.join(HOOKS_DIR);
+		std::fs::create_dir_all(&hooks_folder).unwrap();
+		create_hook_in_path(&hooks_folder.join("commit-msg"), hook);
+
+		let mut msg = String::from("test");
+		let res = hooks_commit_msg(
+			&hooks_folder.to_str().unwrap().into(),
+			&mut msg,
+		)
+		.unwrap();
 		assert_eq!(
 			res,
 			HookResult::NotOk(String::from("rejected\n"))

--- a/asyncgit/src/sync/hooks.rs
+++ b/asyncgit/src/sync/hooks.rs
@@ -97,7 +97,7 @@ mod tests {
 	#[test]
 	fn test_post_commit_hook_reject_in_subfolder() {
 		let (_td, repo) = repo_init().unwrap();
-		let root = repo.path().parent().unwrap();
+		let root = repo.workdir().unwrap();
 
 		let hook = b"#!/bin/sh
 	echo 'rejected'
@@ -130,7 +130,7 @@ mod tests {
 	#[cfg(unix)]
 	fn test_pre_commit_workdir() {
 		let (_td, repo) = repo_init().unwrap();
-		let root = repo.path().parent().unwrap();
+		let root = repo.workdir().unwrap();
 		let repo_path: &RepoPath =
 			&root.as_os_str().to_str().unwrap().into();
 		let workdir =
@@ -160,7 +160,7 @@ mod tests {
 	#[test]
 	fn test_hooks_commit_msg_reject_in_subfolder() {
 		let (_td, repo) = repo_init().unwrap();
-		let root = repo.path().parent().unwrap();
+		let root = repo.workdir().unwrap();
 
 		let hook = b"#!/bin/sh
 	echo 'msg' > $1
@@ -196,7 +196,7 @@ mod tests {
 	fn test_hooks_commit_msg_reject_in_hooks_folder_githooks_moved_absolute(
 	) {
 		let (_td, repo) = repo_init().unwrap();
-		let root = repo.path().parent().unwrap();
+		let root = repo.workdir().unwrap();
 		let mut config = repo.config().unwrap();
 
 		const HOOKS_DIR: &'static str = "my_hooks";


### PR DESCRIPTION
git supports a relative path in core.hooksPath.

`man git-config`:

> A relative path is taken as relative to the directory where the hooks are
> run (see the "DESCRIPTION" section of githooks[5]).

`man githooks`:

> Before Git invokes a hook, it changes its working directory to either
> $GIT_DIR in a bare repository or the root of the working tree in a >
> non-bare repository.

I.e. relative paths in core.hooksPath in non-bare repositories are always relative to GIT_WORK_TREE.

There is a further exception; I believe this is not considered for path resolution:

> An exception are hooks triggered during a push (pre-receive, update,
> post-receive, post-update, push-to-checkout) which are always executed
> in $GIT_DIR.

<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #2281.

It changes the following:
- Synchronizes core.hooksPath resolution with the git command line client

I followed the checklist:
- [x] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog