### PR TITLE
Check cargo sort in `make check`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Select syntax highlighting theme out of the defaults from syntect [[@vasilismanol](https://github.com/vasilismanol)] ([#1931](https://github.com/extrawurst/gitui/issues/1931))
 * new command-line option to override the default log file path (`--logfile`) [[@acuteenvy](https://github.com/acuteenvy)] ([#2539](https://github.com/gitui-org/gitui/pull/2539))
+* dx: `make check` checks Cargo.toml dependency ordering using `cargo sort` [[@naseschwarz](https://github.com/naseschwarz)]
 
 ### Changed
 * improve syntax highlighting file detection [[@acuteenvy](https://github.com/acuteenvy)] ([#2524](https://github.com/extrawurst/gitui/pull/2524))

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-.PHONY: debug build-release release-linux-musl test clippy clippy-pedantic install install-debug
+.PHONY: debug build-release release-linux-musl test clippy clippy-pedantic install install-debug sort
 
 ARGS=-l
 # ARGS=-l -d ~/code/extern/kubernetes
@@ -94,7 +94,7 @@ clippy:
 clippy-nightly:
 	cargo +nightly clippy --workspace --all-features
 
-check: fmt clippy test deny
+check: fmt clippy test deny sort
 
 check-nightly:
 	cargo +nightly c
@@ -103,6 +103,9 @@ check-nightly:
 
 deny:
 	cargo deny check
+
+sort:
+	cargo sort -c -w "."
 
 install:
 	cargo install --path "." --offline --locked


### PR DESCRIPTION
This is run in CI, so running this offline avoids an unnecessary CI failure.

<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #{issue_num}.

It changes the following:
- Adds a `make sort` target, which runs `cargo sort`
- Runs `make sort` also for `make check`

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [ ] I tested the overall application
- [x] I added an appropriate item to the changelog