### PR TITLE
Consolidate recent theme change docs in THEMES.md

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -3,6 +3,8 @@
 default on light terminal:
 ![](assets/light-theme.png)
 
+## Configuration
+
 To change the colors of the default theme you need to add a `theme.ron` file that contains the colors you want to override. Note that you don’t have to specify the full theme anymore (as of 0.23). Instead, it is sufficient to override just the values that you want to differ from their default values.
 
 The file uses the [Ron format](https://github.com/ron-rs/ron) and is located at one of the following paths, depending on your operating system:
@@ -31,7 +33,10 @@ Notes:
 * using a color like `yellow` might appear in whatever your terminal/theme defines for `yellow`
 * valid colors can be found in ratatui's [Color](https://docs.rs/ratatui/latest/ratatui/style/enum.Color.html) struct.
 * all customizable theme elements can be found in [`style.rs` in the `impl Default for Theme` block](https://github.com/gitui-org/gitui/blob/master/src/ui/style.rs#L305)
-* the syntax highlighting theme can be defined using the element `syntax`. Currently, only [default themes of the syntect library are supported](https://github.com/trishume/syntect/blob/7fe13c0fd53cdfa0f9fea1aa14c5ba37f81d8b71/src/dumps.rs#L215).
+
+## Syntax Highlighting
+
+The syntax highlighting theme can be defined using the element `syntax`. Both [default themes of the syntect library are supported](https://github.com/trishume/syntect/blob/7fe13c0fd53cdfa0f9fea1aa14c5ba37f81d8b71/src/dumps.rs#L215) and custom themes are supported.
 
 Example syntax theme:
 ```
@@ -39,6 +44,16 @@ Example syntax theme:
     syntax: Some("InspiredGitHub"),
 )
 ```
+
+Custom themes are located in the [configuration directory](#configuration), are using TextMate's theme format and must have a `.tmTheme` file extension. To load a custom theme, `syntax` must be set to the file name without the file extension. For example, to load [`Blackboard.tmTheme`](https://raw.githubusercontent.com/filmgirl/TextMate-Themes/refs/heads/master/Blackboard.tmTheme), place the file next to `theme.ron` and set:
+```
+(
+    syntax: Some("Blackboard"),
+)
+```
+
+[filmgirl/TextMate-Themes](https://github.com/filmgirl/TextMate-Themes) offers many [beautiful](https://inkdeep.github.io/TextMate-Themes) TextMate themes from which to choose.
+
 ## Customizing line breaks
 
 If you want to change how the line break is displayed in the diff, you can also specify `line_break` in your `theme.ron`:

--- a/THEMES.md
+++ b/THEMES.md
@@ -18,7 +18,7 @@ Alternatively, you can create a theme in the same directory mentioned above and 
 
 Example theme override:
 
-```
+```ron
 (
     selection_bg: Some("Blue"),
     selection_fg: Some("#ffffff"),
@@ -39,14 +39,14 @@ Notes:
 The syntax highlighting theme can be defined using the element `syntax`. Both [default themes of the syntect library are supported](https://github.com/trishume/syntect/blob/7fe13c0fd53cdfa0f9fea1aa14c5ba37f81d8b71/src/dumps.rs#L215) and custom themes are supported.
 
 Example syntax theme:
-```
+```ron
 (
     syntax: Some("InspiredGitHub"),
 )
 ```
 
 Custom themes are located in the [configuration directory](#configuration), are using TextMate's theme format and must have a `.tmTheme` file extension. To load a custom theme, `syntax` must be set to the file name without the file extension. For example, to load [`Blackboard.tmTheme`](https://raw.githubusercontent.com/filmgirl/TextMate-Themes/refs/heads/master/Blackboard.tmTheme), place the file next to `theme.ron` and set:
-```
+```ron
 (
     syntax: Some("Blackboard"),
 )
@@ -58,7 +58,7 @@ Custom themes are located in the [configuration directory](#configuration), are 
 
 If you want to change how the line break is displayed in the diff, you can also specify `line_break` in your `theme.ron`:
 
-```
+```ron
 (
     line_break: Some("¶"),
 )
@@ -66,7 +66,7 @@ If you want to change how the line break is displayed in the diff, you can also 
 
 Note that if you want to turn it off, you should use a blank string:
 
-```
+```ron
 (
     line_break: Some(""),
 )

--- a/THEMES.md
+++ b/THEMES.md
@@ -34,6 +34,10 @@ Notes:
 * valid colors can be found in ratatui's [Color](https://docs.rs/ratatui/latest/ratatui/style/enum.Color.html) struct.
 * all customizable theme elements can be found in [`style.rs` in the `impl Default for Theme` block](https://github.com/gitui-org/gitui/blob/master/src/ui/style.rs#L305)
 
+## Preset Themes
+
+You can find preset themes by Catppuccin [here](https://github.com/catppuccin/gitui.git).
+
 ## Syntax Highlighting
 
 The syntax highlighting theme can be defined using the element `syntax`. Both [default themes of the syntect library are supported](https://github.com/trishume/syntect/blob/7fe13c0fd53cdfa0f9fea1aa14c5ba37f81d8b71/src/dumps.rs#L215) and custom themes are supported.
@@ -71,5 +75,3 @@ Note that if you want to turn it off, you should use a blank string:
     line_break: Some(""),
 )
 ```
-## Preset Themes:
-You can find preset themes by Catppuccin [here](https://github.com/catppuccin/gitui.git)

--- a/THEMES.md
+++ b/THEMES.md
@@ -31,7 +31,14 @@ Notes:
 * using a color like `yellow` might appear in whatever your terminal/theme defines for `yellow`
 * valid colors can be found in ratatui's [Color](https://docs.rs/ratatui/latest/ratatui/style/enum.Color.html) struct.
 * all customizable theme elements can be found in [`style.rs` in the `impl Default for Theme` block](https://github.com/gitui-org/gitui/blob/master/src/ui/style.rs#L305)
+* the syntax highlighting theme can be defined using the element `syntax`. Currently, only [default themes of the syntect library are supported](https://github.com/trishume/syntect/blob/7fe13c0fd53cdfa0f9fea1aa14c5ba37f81d8b71/src/dumps.rs#L215).
 
+Example syntax theme:
+```
+(
+    syntax: Some("InspiredGitHub"),
+)
+```
 ## Customizing line breaks
 
 If you want to change how the line break is displayed in the diff, you can also specify `line_break` in your `theme.ron`:

--- a/THEMES.md
+++ b/THEMES.md
@@ -56,3 +56,5 @@ Note that if you want to turn it off, you should use a blank string:
     line_break: Some(""),
 )
 ```
+## Preset Themes:
+You can find preset themes by Catppuccin [here](https://github.com/catppuccin/gitui.git)

--- a/THEMES.md
+++ b/THEMES.md
@@ -40,7 +40,7 @@ You can find preset themes by Catppuccin [here](https://github.com/catppuccin/gi
 
 ## Syntax Highlighting
 
-The syntax highlighting theme can be defined using the element `syntax`. Both [default themes of the syntect library are supported](https://github.com/trishume/syntect/blob/7fe13c0fd53cdfa0f9fea1aa14c5ba37f81d8b71/src/dumps.rs#L215) and custom themes are supported.
+The syntax highlighting theme can be defined using the element `syntax`. Both [default themes of the syntect library](https://github.com/trishume/syntect/blob/7fe13c0fd53cdfa0f9fea1aa14c5ba37f81d8b71/src/dumps.rs#L215) and custom themes are supported.
 
 Example syntax theme:
 ```ron

--- a/THEMES.md
+++ b/THEMES.md
@@ -56,7 +56,7 @@ Custom themes are located in the [configuration directory](#configuration), are 
 )
 ```
 
-[filmgirl/TextMate-Themes](https://github.com/filmgirl/TextMate-Themes) offers many [beautiful](https://inkdeep.github.io/TextMate-Themes) TextMate themes from which to choose.
+[filmgirl/TextMate-Themes](https://github.com/filmgirl/TextMate-Themes) offers many [beautiful](https://inkdeep.github.io/TextMate-Themes) TextMate themes to choose from.
 
 ## Customizing line breaks
 


### PR DESCRIPTION
This pull request consolidates #2570, #2214, #2564 (via #2573) into a single pull. The result from just merging seemed random, this adds a bit more structure to the document.

It changes the following:
- Add to THEME.md:
  - Custom syntax highlighting
    - Using default syntect themes (picked form #2570)
    - Using custom TextMate themes (for #2573)
  - Reference themes (picked from #2214)
- Enables syntax highlighting for RON data in THEME.md

I followed the checklist:
- [x] Checked the THEMES.md rendering on github.
- ~~I added unittests~~
- ~~I ran `make check` without errors~~
- ~~I tested the overall application~~
- ~~I added an appropriate item to the changelog~~