### PR TITLE
Disable dotted range commit yanking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * set the terminal title to `gitui ({repo_path})` [[@acuteenvy](https://github.com/acuteenvy)] ([#2462](https://github.com/gitui-org/gitui/issues/2462))
 * respect `.mailmap` [[@acuteenvy](https://github.com/acuteenvy)] ([#2406](https://github.com/gitui-org/gitui/issues/2406))
 
+### Fixes
+* yanking commit ranges no longer generates incorrect dotted range notations, but lists each individual commit [[@naseschwarz](https://github.com/naseschwarz)] (https://github.com/gitui-org/gitui/issues/2576)
+
 ## [0.27.0] - 2024-01-14
 
 **new: manage remotes**

--- a/asyncgit/src/sync/commits_info.rs
+++ b/asyncgit/src/sync/commits_info.rs
@@ -49,6 +49,18 @@ impl CommitId {
 		let commit_obj = repo.revparse_single(revision)?;
 		Ok(commit_obj.id().into())
 	}
+
+	/// Tries to convert a &str representation of a commit id into
+	/// a `CommitId`
+	pub fn from_str_unchecked(commit_id_str: &str) -> Result<Self> {
+		match Oid::from_str(commit_id_str) {
+			Err(e) => Err(crate::Error::Generic(format!(
+				"Could not convert {}",
+				e.message()
+			))),
+			Ok(v) => Ok(Self::new(v)),
+		}
+	}
 }
 
 impl Display for CommitId {
@@ -73,7 +85,7 @@ impl From<Oid> for CommitId {
 }
 
 ///
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CommitInfo {
 	///
 	pub message: String,

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -160,7 +160,7 @@ pub enum InternalEvent {
 }
 
 /// single threaded simple queue for components to communicate with each other
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Queue {
 	data: Rc<RefCell<VecDeque<InternalEvent>>>,
 }


### PR DESCRIPTION
The algorithm for computing marked_consecutive assumes that commits are consecutive in the commit graph if they are consecutive in the linearized log used in` commitlist.rs`. That is not universally correct, as siblings may also be displayed consecutively in this list.

For now, this just removes generating commit lists in dotted range notation.

<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #2576 

It changes the following:
- Removes dotted range notation commit yanking

I followed the checklist:
- [x] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog