### PR TITLE
Fix #315 run brew test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,3 +275,31 @@ jobs:
       with:
         name: release-notes.txt
         path: ./release-notes.txt
+
+  test-homebrew:
+    name: Test Homebrew Formula (macOS)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Install Homebrew
+        run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+      - name: Set up Homebrew in PATH
+        run: |
+          echo "$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" >> $GITHUB_PATH
+
+      - name: Update Homebrew
+        run: brew update
+
+      - name: Let Homebrew build gitui from source
+        run: brew install --head --build-from-source gitui
+
+      - name: Run Homebrew test
+        run: brew test gitui


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #315 .

It changes the following:
- CI script has a new job that build gitui from source at head, using brew, and runs brew test

I followed the checklist:
- [no] I added unittests
- [no] I ran `make check` without errors
- [no] I tested the overall application
- [no] I added an appropriate item to the changelog

..but, I did make a custom tap of brew, introduced an error in the source code on my fork and let my custom brew discover it. 

The thing is, there is no change to the source code of gitui, only to the CI script. The change looks at gitui main branch head, which I cannot touch - so I had to hack around to fake a test. I have demonstrated that it works on my fork, but not that it works on gitui master branch.