### PR TITLE
Remove some `#[allow]`s II

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -38,7 +38,6 @@ pub fn process_cmdline() -> Result<CliArgs> {
 		.get_one::<String>("directory")
 		.map_or_else(|| PathBuf::from("."), PathBuf::from);
 
-	#[allow(clippy::option_if_let_else)]
 	let repo_path = if let Some(w) = workdir {
 		RepoPath::Workdir { gitdir, workdir: w }
 	} else {

--- a/src/components/commit_details/compare_details.rs
+++ b/src/components/commit_details/compare_details.rs
@@ -58,7 +58,6 @@ impl CompareDetailsComponent {
 		});
 	}
 
-	#[allow(unstable_name_collisions)]
 	fn get_commit_text(&self, data: &CommitDetails) -> Vec<Line> {
 		let mut res = vec![
 			Line::from(vec![

--- a/src/components/commit_details/details.rs
+++ b/src/components/commit_details/details.rs
@@ -155,7 +155,7 @@ impl DetailsComponent {
 			.collect()
 	}
 
-	#[allow(unstable_name_collisions, clippy::too_many_lines)]
+	#[allow(clippy::too_many_lines)]
 	fn get_text_info(&self) -> Vec<Line> {
 		self.data.as_ref().map_or_else(Vec::new, |data| {
 			let mut res = vec![


### PR DESCRIPTION
It changes the following:
- Remove unneeded `#[allow]`s, `rg '#.*allow' | wc -l` from 28 to 26.

I followed the checklist:
- ~~I added unittests~~
- [x] I ran `make check` without errors
- [x] I tested the overall application
- ~~I added an appropriate item to the changelog~~