### PR TITLE
Improve error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * add `use_selection_fg` to theme file to allow customizing selection foreground color [[@Upsylonbare](https://github.com/Upsylonbare)] ([#2515](https://github.com/gitui-org/gitui/pull/2515))
 
 ### Changed
+* improve error messages [[@acuteenvy](https://github.com/acuteenvy)] ([#2617](https://github.com/gitui-org/gitui/pull/2617))
 * increase MSRV from 1.70 to 1.81 [[@naseschwarz](https://github.com/naseschwarz)] ([#2094](https://github.com/gitui-org/gitui/issues/2094))
 * improve syntax highlighting file detection [[@acuteenvy](https://github.com/acuteenvy)] ([#2524](https://github.com/extrawurst/gitui/pull/2524))
 * Updated project links to point to `gitui-org` instead of `extrawurst`  [[@vasleymus](https://github.com/vasleymus)] ([#2538](https://github.com/gitui-org/gitui/pull/2538))

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,6 @@ use std::{
 	io::{self, Stdout},
 	panic,
 	path::Path,
-	process,
 	time::{Duration, Instant},
 };
 use ui::style::Theme;
@@ -120,20 +119,24 @@ enum Updater {
 	NotifyWatcher,
 }
 
+/// Do `log::error!` and `eprintln!` in one line.
+macro_rules! log_eprintln {
+	( $($arg:tt)* ) => {{
+		log::error!($($arg)*);
+		eprintln!($($arg)*);
+	}};
+}
+
 fn main() -> Result<()> {
 	let app_start = Instant::now();
 
 	let cliargs = process_cmdline()?;
 
 	asyncgit::register_tracing_logging();
-
-	if !valid_path(&cliargs.repo_path) {
-		eprintln!("invalid path\nplease run gitui inside of a non-bare git repository");
-		return Ok(());
-	}
+	ensure_valid_path(&cliargs.repo_path)?;
 
 	let key_config = KeyConfig::init()
-		.map_err(|e| eprintln!("KeyConfig loading error: {e}"))
+		.map_err(|e| log_eprintln!("KeyConfig loading error: {e}"))
 		.unwrap_or_default();
 	let theme = Theme::init(&cliargs.theme);
 
@@ -142,7 +145,7 @@ fn main() -> Result<()> {
 		shutdown_terminal();
 	}
 
-	set_panic_handlers()?;
+	set_panic_handler()?;
 
 	let mut repo_path = cliargs.repo_path;
 	let mut terminal = start_terminal(io::stdout(), &repo_path)?;
@@ -292,13 +295,13 @@ fn shutdown_terminal() {
 		io::stdout().execute(LeaveAlternateScreen).map(|_f| ());
 
 	if let Err(e) = leave_screen {
-		eprintln!("leave_screen failed:\n{e}");
+		log::error!("leave_screen failed:\n{e}");
 	}
 
 	let leave_raw_mode = disable_raw_mode();
 
 	if let Err(e) = leave_raw_mode {
-		eprintln!("leave_raw_mode failed:\n{e}");
+		log::error!("leave_raw_mode failed:\n{e}");
 	}
 }
 
@@ -316,12 +319,14 @@ fn draw(terminal: &mut Terminal, app: &App) -> io::Result<()> {
 	Ok(())
 }
 
-fn valid_path(repo_path: &RepoPath) -> bool {
-	let error = asyncgit::sync::repo_open_error(repo_path);
-	if let Some(error) = &error {
-		log::error!("repo open error: {error}");
+fn ensure_valid_path(repo_path: &RepoPath) -> Result<()> {
+	match asyncgit::sync::repo_open_error(repo_path) {
+		Some(e) => {
+			log::error!("{e}");
+			bail!(e)
+		}
+		None => Ok(()),
 	}
-	error.is_none()
 }
 
 fn select_event(
@@ -389,30 +394,15 @@ fn start_terminal(
 	Ok(terminal)
 }
 
-// do log::error! and eprintln! in one line, pass string, error and backtrace
-macro_rules! log_eprintln {
-	($string:expr, $e:expr, $bt:expr) => {
-		log::error!($string, $e, $bt);
-		eprintln!($string, $e, $bt);
-	};
-}
-
-fn set_panic_handlers() -> Result<()> {
-	// regular panic handler
+fn set_panic_handler() -> Result<()> {
 	panic::set_hook(Box::new(|e| {
 		let backtrace = Backtrace::new();
 		shutdown_terminal();
-		log_eprintln!("\nGitUI was close due to an unexpected panic.\nPlease file an issue on https://github.com/gitui-org/gitui/issues with the following info:\n\n{:?}\ntrace:\n{:?}", e, backtrace);
+		log_eprintln!("\nGitUI was closed due to an unexpected panic.\nPlease file an issue on https://github.com/gitui-org/gitui/issues with the following info:\n\n{e}\n\ntrace:\n{backtrace:?}");
 	}));
 
 	// global threadpool
 	rayon_core::ThreadPoolBuilder::new()
-		.panic_handler(|e| {
-			let backtrace = Backtrace::new();
-			shutdown_terminal();
-			log_eprintln!("\nGitUI was close due to an unexpected panic.\nPlease file an issue on https://github.com/gitui-org/gitui/issues with the following info:\n\n{:?}\ntrace:\n{:?}", e, backtrace);
-			process::abort();
-		})
 		.num_threads(4)
 		.build_global()?;
 


### PR DESCRIPTION
This Pull Request fixes/closes #2599.

It changes the following:
- Improve error messages when the repository cannot be opened.
  - for example, when the repo doesn't exist:
  ```sh
  # previously
  $ gitui
  invalid path
  please run gitui inside of a non-bare git repository
  
  # now
  $ gitui
  Error: could not find repository at '.'; class=Repository (6); code=NotFound (-3)
  ```
- Remove the panic handler from rayon, since `panic::set_hook` already handles all panics. Setting both panic handlers causes the panic message to be displayed twice.
- Do both `log::error!` and `eprintln!` wherever possible

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
  - ~~I get some errors in `Cargo.toml`, but it hasn't been changed in this PR:~~ (see https://github.com/gitui-org/gitui/pull/2617#issuecomment-2810329134)
  ```
  error: Dependencies for . are not sorted
  error: Cargo.toml for . is not formatted
  Checking asyncgit...
  Checking filetreelist...
  Checking git2-hooks...
  Checking git2-testing...
  Checking scopetime...
  error: Dependencies for scopetime are not sorted
  error: Cargo.toml for scopetime is not formatted
  make: *** [Makefile:108: sort] Error 1
  ```
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog