### PR TITLE
Show cursor on panic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -288,8 +288,10 @@ fn setup_terminal() -> Result<()> {
 }
 
 fn shutdown_terminal() {
+	let mut stdout = io::stdout();
+
 	let leave_screen =
-		io::stdout().execute(LeaveAlternateScreen).map(|_f| ());
+		stdout.execute(LeaveAlternateScreen).map(|_f| ());
 
 	if let Err(e) = leave_screen {
 		eprintln!("leave_screen failed:\n{e}");
@@ -299,6 +301,10 @@ fn shutdown_terminal() {
 
 	if let Err(e) = leave_raw_mode {
 		eprintln!("leave_raw_mode failed:\n{e}");
+	}
+
+	if let Err(e) = stdout.execute(crossterm::cursor::Show) {
+		eprintln!("Showing cursor failed:\n{e}");
 	}
 }
 


### PR DESCRIPTION
ratatui::Terminal starts by hiding the cursor. If we panic and abort, that Terminal instance is not dropped, which leaves restoring the cursor state to us.

It changes the following:
- Shows the terminal cursor if gitui panics

I followed the checklist:
- ~~I added unittests~~
- [x] I ran `make check` without errors
- [x] I tested the overall application
- ~~I added an appropriate item to the changelog~~
  - left out intentionally for such a minor item