### PR TITLE
Feat/respect xdg spec on all os

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * add `use_selection_fg` to theme file to allow customizing selection foreground color [[@Upsylonbare](https://github.com/Upsylonbare)] ([#2515](https://github.com/gitui-org/gitui/pull/2515))
 
 ### Changed
+* Respect `XDG_CONFIG_HOME` and `XDG_CACHE_HOME` irrespective of OS [[@KlassyKat](https://github.com/KlassyKat)] ([#1498](https://github.com/gitui-org/gitui/issues/1498))
 * improve error messages [[@acuteenvy](https://github.com/acuteenvy)] ([#2617](https://github.com/gitui-org/gitui/pull/2617))
 * increase MSRV from 1.70 to 1.81 [[@naseschwarz](https://github.com/naseschwarz)] ([#2094](https://github.com/gitui-org/gitui/issues/2094))
 * improve syntax highlighting file detection [[@acuteenvy](https://github.com/acuteenvy)] ([#2524](https://github.com/extrawurst/gitui/pull/2524))

--- a/KEY_CONFIG.md
+++ b/KEY_CONFIG.md
@@ -19,12 +19,17 @@ Create a `key_bindings.ron` file like this:
 )
 ```
 
-The config file format based on the [Ron file format](https://github.com/ron-rs/ron).
+The keybinding config file uses the [Ron file format](https://github.com/ron-rs/ron).
 The location of the file depends on your OS:
-* `$HOME/.config/gitui/key_bindings.ron` (mac)
-* `$XDG_CONFIG_HOME/gitui/key_bindings.ron` (linux using XDG)
-* `$HOME/.config/gitui/key_bindings.ron` (linux)
-* `%APPDATA%/gitui/key_bindings.ron` (Windows)
+`gitui` will look for an existing `/gitui` in the following order:
+* `$XDG_CONFIG_HOME/gitui/` (with `XDG_CONFIG_HOME` set)
+* `$HOME/.config/gitui/`
+* Default OS Location:
+    * `$HOME/Library/Application Support/` (mac)
+    * `$HOME/.config/gitui/` (linux)
+    * `%APPDATA%/gitui/` (Windows)
+
+Key bindings are configured in `key_bindings.ron` within your first found `gitui` config folder.
 
 See all possible keys to overwrite in gitui: [here](https://github.com/gitui-org/gitui/blob/master/src/keys/key_list.rs#L83)
 

--- a/README.md
+++ b/README.md
@@ -250,9 +250,9 @@ see [FAQs page](./FAQ.md)
 To run with logging enabled run `gitui -l`.
 
 This will log to:
-
+- With `XDG_CACHE_HOME` set: `$XDG_CACHE_HOME/gitui/gitui.log`
+or default to
 - macOS: `$HOME/Library/Caches/gitui/gitui.log`
-- Linux using `XDG`: `$XDG_CACHE_HOME/gitui/gitui.log`
 - Linux: `$HOME/.cache/gitui/gitui.log`
 - Windows: `%LOCALAPPDATA%/gitui/gitui.log`
 

--- a/THEMES.md
+++ b/THEMES.md
@@ -7,14 +7,19 @@ default on light terminal:
 
 To change the colors of the default theme you need to add a `theme.ron` file that contains the colors you want to override. Note that you don’t have to specify the full theme anymore (as of 0.23). Instead, it is sufficient to override just the values that you want to differ from their default values.
 
-The file uses the [Ron format](https://github.com/ron-rs/ron) and is located at one of the following paths, depending on your operating system:
+The theme file uses the [Ron file format](https://github.com/ron-rs/ron).
+The location of the file depends on your OS:
+`gitui` will look for an existing `/gitui` in the following order:
+* `$XDG_CONFIG_HOME/gitui/` (with `XDG_CONFIG_HOME` set)
+* `$HOME/.config/gitui/`
+* Default OS Location:
+    * `$HOME/Library/Application Support/` (mac)
+    * `$HOME/.config/gitui/` (linux)
+    * `%APPDATA%/gitui/` (Windows)
 
-* `$HOME/.config/gitui/theme.ron` (mac)
-* `$XDG_CONFIG_HOME/gitui/theme.ron` (linux using XDG)
-* `$HOME/.config/gitui/theme.ron` (linux)
-* `%APPDATA%/gitui/theme.ron` (Windows)
+The theme is configured in `theme.ron` within your first found `gitui` config folder.
 
-Alternatively, you can create a theme in the same directory mentioned above and use it with the `-t` flag followed by the name of the file in the directory. E.g. If you are on linux calling `gitui -t arc.ron`, this will load the theme in `$XDG_CONFIG_HOME/gitui/arc.ron` or `$HOME/.config/gitui/arc.ron`.
+Alternatively, you can create a theme in the same directory mentioned above and use it with the `-t` flag followed by the name of the file in the directory. E.g. Calling `gitui -t arc.ron` will load the `arc.ron` theme from your first found `/gitui` config folder using the logic above.
 
 Example theme override:
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -49,7 +49,6 @@ pub fn process_cmdline() -> Result<CliArgs> {
 		.map_or_else(|| PathBuf::from("theme.ron"), PathBuf::from);
 
 	let confpath = get_app_config_path()?;
-	fs::create_dir_all(&confpath)?;
 	let theme = confpath.join(arg_theme);
 
 	let notify_watcher: bool =

--- a/src/args.rs
+++ b/src/args.rs
@@ -149,15 +149,17 @@ fn setup_logging(path_override: Option<PathBuf>) -> Result<()> {
 	Ok(())
 }
 
-fn get_path_from_canidates(
-	canidates: Vec<Option<PathBuf>>,
+fn get_path_from_candidates(
+	candidates: Vec<Option<PathBuf>>,
 ) -> Result<PathBuf> {
-	let valid_canidates =
-		canidates.into_iter().flatten().filter(|path| path.is_dir());
+	let valid_candidates = candidates
+		.into_iter()
+		.flatten()
+		.filter(|path| path.is_dir());
 
 	let mut target_dir = None;
 
-	for potential_dir in valid_canidates {
+	for potential_dir in valid_candidates {
 		let search_path = potential_dir.join("gitui");
 
 		// Prefer preexisting gitui directory
@@ -171,19 +173,19 @@ fn get_path_from_canidates(
 	}
 
 	let dir = target_dir.ok_or_else(|| {
-		anyhow!("failed to find valid path within canidates")
+		anyhow!("failed to find valid path within candidates")
 	})?;
 
 	Ok(dir)
 }
 
 fn get_app_cache_path() -> Result<PathBuf> {
-	let cache_dir_canidates = vec![
+	let cache_dir_candidates = vec![
 		env::var_os("XDG_CACHE_HOME").map(PathBuf::from),
 		dirs::cache_dir(),
 	];
 
-	match get_path_from_canidates(cache_dir_canidates) {
+	match get_path_from_candidates(cache_dir_candidates) {
 		Ok(cache_dir) => {
 			fs::create_dir_all(&cache_dir)?;
 			Ok(cache_dir)
@@ -194,7 +196,7 @@ fn get_app_cache_path() -> Result<PathBuf> {
 
 pub fn get_app_config_path() -> Result<PathBuf> {
 	// List of potential config directories in order of priority
-	let config_dir_canidates = vec![
+	let config_dir_candidates = vec![
 		env::var_os("XDG_CONFIG_HOME").map(PathBuf::from),
 		// This is in the list since it was the hardcoded behavior on macos before
 		// I expect this to be what most people have XDG_CONFIG_HOME set to already
@@ -203,7 +205,7 @@ pub fn get_app_config_path() -> Result<PathBuf> {
 		dirs::config_dir(),
 	];
 
-	get_path_from_canidates(config_dir_canidates)
+	get_path_from_candidates(config_dir_candidates)
 		.map_err(|_| anyhow!("failed to find os config dir."))
 }
 


### PR DESCRIPTION
This Pull Request fixes/closes #1498.

It changes the following:
- Unifies OS logic for loading config.
- Adds a ordered list of locations to search for config.
- List includes `XDG_CONFIG_HOME` as the first priority.
- Implements the same logic for getting the cache_path with `XDG_CACHE_HOME` as the top priority
- No longer creates an empty `gitui` config folder by default.

I followed the checklist:
- [x] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [x] I added an appropriate item to the changelog