### PR TITLE
Avoid exposing internal tuple in CommitList.marked

### DIFF
--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -45,6 +45,8 @@ pub struct CommitList {
 	items: ItemBatch,
 	highlights: Option<Rc<IndexSet<CommitId>>>,
 	commits: IndexSet<CommitId>,
+	/// Commits that are marked. The .0 is used to provide a sort order.
+	/// It contains an index into self.items.items
 	marked: Vec<(usize, CommitId)>,
 	scroll_state: (Instant, f32),
 	tags: Option<Tags>,

--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -117,15 +117,6 @@ impl CommitList {
 	}
 
 	///
-	#[expect(
-		clippy::missing_const_for_fn,
-		reason = "as of 1.86.0 clippy wants this to be const even though that breaks"
-	)]
-	pub fn marked(&self) -> &[(usize, CommitId)] {
-		&self.marked
-	}
-
-	///
 	pub fn clear_marked(&mut self) {
 		self.marked.clear();
 	}

--- a/src/tabs/revlog.rs
+++ b/src/tabs/revlog.rs
@@ -586,19 +586,19 @@ impl Component for Revlog {
 						self.queue.push(InternalEvent::OpenPopup(
 							StackablePopupOpen::CompareCommits(
 								InspectCommitOpen::new(
-									self.list.marked()[0].1,
+									self.list.marked_commits()[0],
 								),
 							),
 						));
 						return Ok(EventState::Consumed);
 					} else if self.list.marked_count() == 2 {
 						//compare two marked commits
-						let marked = self.list.marked();
+						let marked = self.list.marked_commits();
 						self.queue.push(InternalEvent::OpenPopup(
 							StackablePopupOpen::CompareCommits(
 								InspectCommitOpen {
-									commit_id: marked[0].1,
-									compare_id: Some(marked[1].1),
+									commit_id: marked[0],
+									compare_id: Some(marked[1]),
 									tags: None,
 								},
 							),


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request is a minor cleanup

It changes the following:
- Use a different function to avoid exposing the tuple used to sort commit id in CommitList.marked

I followed the checklist:
- [ ] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog