### PR TITLE
feat: use `git commit --verbose` template in external editor

### DIFF
--- a/asyncgit/src/sync/commit.rs
+++ b/asyncgit/src/sync/commit.rs
@@ -182,18 +182,26 @@ pub fn tag_commit(
 }
 
 /// Loads the comment prefix from config & uses it to prettify commit messages
+///
+/// Also removes any lines after the scissors line.
 pub fn commit_message_prettify(
 	repo_path: &RepoPath,
-	message: String,
+	message: &str,
 ) -> Result<String> {
 	let comment_char = repo(repo_path)?
 		.config()?
 		.get_string("core.commentChar")
 		.ok()
 		.and_then(|char_string| char_string.chars().next())
-		.unwrap_or('#') as u8;
+		.unwrap_or('#');
+	let scissors_line = format!("{comment_char} ------------------------ >8 ------------------------");
+	let message = message
+		.lines()
+		.take_while(|line| line != &scissors_line)
+		.collect::<Vec<_>>()
+		.join("\n");
 
-	Ok(message_prettify(message, Some(comment_char))?)
+	Ok(message_prettify(message, Some(comment_char as u8))?)
 }
 
 #[cfg(test)]
@@ -468,7 +476,7 @@ mod tests {
 
 		let message = commit_message_prettify(
 			repo_path,
-			"#This is a test message\nTest".to_owned(),
+			"#This is a test message\nTest",
 		)?;
 
 		assert_eq!(message, "Test\n");
@@ -487,7 +495,27 @@ mod tests {
 
 		let message = commit_message_prettify(
 			repo_path,
-			";This is a test message\nTest".to_owned(),
+			";This is a test message\nTest",
+		)?;
+
+		assert_eq!(message, "Test\n");
+
+		Ok(())
+	}
+
+	#[test]
+	fn test_scissors_line() -> Result<()> {
+		let (_td, repo) = repo_init_empty().unwrap();
+
+		let root = repo.path().parent().unwrap();
+		let repo_path: &RepoPath =
+			&root.as_os_str().to_str().unwrap().into();
+
+		repo.config()?.set_str("core.commentChar", ";")?;
+
+		let message = commit_message_prettify(
+			repo_path,
+			";This is a test message\nTest\n; ------------------------ >8 ------------------------\nTest2\nTest3\nTest4",
 		)?;
 
 		assert_eq!(message, "Test\n");

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -105,7 +105,8 @@ pub use tags::{
 pub use tree::{tree_file_content, tree_files, TreeFile};
 pub use utils::{
 	get_head, get_head_tuple, repo_dir, repo_open_error,
-	stage_add_all, stage_add_file, stage_addremoved, Head,
+	repo_work_dir, stage_add_all, stage_add_file, stage_addremoved,
+	Head,
 };
 
 pub use git2::ResetType;

--- a/src/app.rs
+++ b/src/app.rs
@@ -359,9 +359,7 @@ impl App {
 							Path::new(&path),
 						)
 					} else {
-						let changes =
-							self.status_tab.get_files_changes()?;
-						self.commit_popup.show_editor(changes)
+						self.commit_popup.show_editor()
 					};
 
 				if let Err(e) = result {

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -131,12 +131,6 @@ pub fn commit_first_line_warning(count: usize) -> String {
 pub const fn branch_name_invalid() -> &'static str {
 	"[invalid name]"
 }
-pub fn commit_editor_msg(_key_config: &SharedKeyConfig) -> String {
-	r"
-# Edit your commit message
-# Lines starting with '#' will be ignored"
-		.to_string()
-}
 pub fn stash_popup_title(_key_config: &SharedKeyConfig) -> String {
 	"Stash".to_string()
 }

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -21,7 +21,7 @@ use asyncgit::{
 	},
 	sync::{BranchCompare, CommitId},
 	AsyncDiff, AsyncGitNotification, AsyncStatus, DiffParams,
-	DiffType, PushType, StatusItem, StatusParams,
+	DiffType, PushType, StatusParams,
 };
 use crossterm::event::Event;
 use itertools::Itertools;
@@ -449,10 +449,6 @@ impl Status {
 		}
 
 		Ok(())
-	}
-
-	pub fn get_files_changes(&self) -> Result<Vec<StatusItem>> {
-		Ok(self.git_status_stage.last()?.items)
 	}
 
 	fn update_status(&mut self) -> Result<()> {


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request closes #2619.

It changes the following:
- When opening the external editor on a commit message, use template from `git commit --verbose` which includes full diff of the commit.

I followed the checklist:
- [x] I added unittests
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog