### PR TITLE
Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  groups:
+    cargo:
+      patterns: ["*"]


### PR DESCRIPTION
This PR configures Dependabot to use one grouped PR instead of individual PRs for its daily updates.
