### PR TITLE
Have cargo-sort 2.0.1 sort Cargo.toml's

### DIFF
--- a/asyncgit/Cargo.toml
+++ b/asyncgit/Cargo.toml
@@ -11,6 +11,11 @@ license = "MIT"
 categories = ["concurrency", "asynchronous"]
 keywords = ["git"]
 
+[features]
+default = ["trace-libgit"]
+trace-libgit = []
+vendor-openssl = ["openssl-sys"]
+
 [dependencies]
 bitflags = "2"
 crossbeam-channel = "0.5"
@@ -43,8 +48,3 @@ invalidstring = { path = "../invalidstring", version = "0.1" }
 pretty_assertions = "1.4"
 serial_test = "3.2"
 tempfile = "3"
-
-[features]
-default = ["trace-libgit"]
-trace-libgit = []
-vendor-openssl = ["openssl-sys"]

--- a/scopetime/Cargo.toml
+++ b/scopetime/Cargo.toml
@@ -11,9 +11,9 @@ readme = "README.md"
 categories = ["development-tools::profiling"]
 keywords = ["profiling", "logging"]
 
+[features]
+default = []
+enabled = []
+
 [dependencies]
 log = "0.4"
-
-[features]
-default =[]
-enabled =[]


### PR DESCRIPTION
This PR is supposed to fix the lint step on CI.
