### PR TITLE
Use `gitoxide` in `get_commit_info`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,6 +1224,7 @@ dependencies = [
  "gix-hashtable",
  "gix-index",
  "gix-lock",
+ "gix-mailmap",
  "gix-object",
  "gix-odb",
  "gix-pack",
@@ -1483,6 +1484,18 @@ checksum = "df47b8f11c34520db5541bc5fc9fbc8e4b0bdfcec3736af89ccb1a5728a0126f"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "gix-mailmap"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff80d086d2684d30c5785cc37eba9d2cf817cfb33797ed999db9a359d16ab393"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
  "thiserror 2.0.12",
 ]
 

--- a/asyncgit/Cargo.toml
+++ b/asyncgit/Cargo.toml
@@ -27,6 +27,7 @@ git2-hooks = { path = "../git2-hooks", version = ">=0.4" }
 gix = { version = "0.71.0", default-features = false, features = [
     "max-performance",
     "revision",
+    "mailmap"
 ] }
 log = "0.4"
 # git2 = { path = "../../extern/git2-rs", features = ["vendored-openssl"]}

--- a/asyncgit/src/error.rs
+++ b/asyncgit/src/error.rs
@@ -114,6 +114,16 @@ pub enum Error {
 	GixRevisionWalk(#[from] gix::revision::walk::Error),
 
 	///
+	#[error("gix::objs::decode::Error error: {0}")]
+	GixObjsDecode(#[from] gix::objs::decode::Error),
+
+	///
+	#[error("gix::object::find::existing::with_conversion::Error error: {0}")]
+	GixObjectFindExistingWithConversionError(
+		#[from] gix::object::find::existing::with_conversion::Error,
+	),
+
+	///
 	#[error("amend error: config commit.gpgsign=true detected.\ngpg signing is not supported for amending non-last commits")]
 	SignAmendNonLastCommit,
 

--- a/asyncgit/src/sync/commits_info.rs
+++ b/asyncgit/src/sync/commits_info.rs
@@ -93,6 +93,12 @@ impl From<gix::ObjectId> for CommitId {
 	}
 }
 
+impl From<CommitId> for gix::ObjectId {
+	fn from(id: CommitId) -> Self {
+		Self::from_bytes_or_panic(id.0.as_bytes())
+	}
+}
+
 ///
 #[derive(Debug, Clone)]
 pub struct CommitInfo {
@@ -151,24 +157,35 @@ pub fn get_commit_info(
 ) -> Result<CommitInfo> {
 	scope_time!("get_commit_info");
 
-	let repo = repo(repo_path)?;
-	let mailmap = repo.mailmap()?;
+	let repo: gix::Repository =
+				gix::ThreadSafeRepository::discover_with_environment_overrides(repo_path.gitpath())
+						.map(Into::into)?;
+	let mailmap = repo.open_mailmap();
 
-	let commit = repo.find_commit((*commit_id).into())?;
-	let author = get_author_of_commit(&commit, &mailmap);
+	let commit = repo.find_commit(*commit_id)?;
+	let commit_ref = commit.decode()?;
+
+	let message = gix_get_message(&commit_ref, None);
+
+	let author = commit_ref.author();
+
+	let author = mailmap.try_resolve(author).map_or_else(
+		|| author.name.into(),
+		|signature| signature.name,
+	);
 
 	Ok(CommitInfo {
-		message: commit.message().unwrap_or("").into(),
-		author: author.name().unwrap_or("<unknown>").into(),
-		time: commit.time().seconds(),
-		id: CommitId(commit.id()),
+		message,
+		author: author.to_string(),
+		time: commit_ref.time().seconds,
+		id: commit.id().detach().into(),
 	})
 }
 
 /// if `message_limit` is set the message will be
 /// limited to the first line and truncated to fit
 pub fn get_message(
-	c: &Commit,
+	c: &git2::Commit,
 	message_limit: Option<usize>,
 ) -> String {
 	let msg = String::from_utf8_lossy(c.message_bytes());
@@ -179,6 +196,24 @@ pub fn get_message(
 		|limit| {
 			let msg = msg.lines().next().unwrap_or_default();
 			msg.unicode_truncate(limit).0.to_string()
+		},
+	)
+}
+
+/// if `message_limit` is set the message will be
+/// limited to the first line and truncated to fit
+pub fn gix_get_message(
+	commit_ref: &gix::objs::CommitRef,
+	message_limit: Option<usize>,
+) -> String {
+	let message = commit_ref.message.to_string();
+	let message = message.trim();
+
+	message_limit.map_or_else(
+		|| message.to_string(),
+		|limit| {
+			let message = message.lines().next().unwrap_or_default();
+			message.unicode_truncate(limit).0.to_string()
 		},
 	)
 }

--- a/asyncgit/src/sync/commits_info.rs
+++ b/asyncgit/src/sync/commits_info.rs
@@ -84,6 +84,15 @@ impl From<Oid> for CommitId {
 	}
 }
 
+impl From<gix::ObjectId> for CommitId {
+	fn from(object_id: gix::ObjectId) -> Self {
+		#[allow(clippy::expect_used)]
+		let oid = Oid::from_bytes(object_id.as_bytes()).expect("`Oid::from_bytes(object_id.as_bytes())` is expected to never fail");
+
+		Self::new(oid)
+	}
+}
+
 ///
 #[derive(Debug, Clone)]
 pub struct CommitInfo {

--- a/asyncgit/src/sync/logwalker.rs
+++ b/asyncgit/src/sync/logwalker.rs
@@ -161,10 +161,7 @@ impl<'a> LogWalkerWithoutFilter<'a> {
 		let mut count = 0_usize;
 
 		while let Some(Ok(info)) = self.walk.next() {
-			let bytes = info.id.as_bytes();
-			let commit_id: CommitId = Oid::from_bytes(bytes)?.into();
-
-			out.push(commit_id);
+			out.push(info.id.into());
 
 			count += 1;
 


### PR DESCRIPTION
This is related to #2643. I have not been able to figure out why #2643 sometimes fails on CI, but in a way that I have not been able to reproduce locally. So I thought I’d split out the parts that are not related to the CI failures to maybe get them merged earlier. While the initial PR converted both `get_commits_info` (plural) and `get_commit_info` (singular) to `gitoxide`, this PR only converts `get_commit_info`. Apart from that, it is the same as #2643.
