### PR TITLE
Use `gitoxide` for `get_tags`

### DIFF
--- a/asyncgit/src/error.rs
+++ b/asyncgit/src/error.rs
@@ -17,7 +17,7 @@ pub enum GixError {
 
 	///
 	#[error("gix::object::find::existing::with_conversion::Error error: {0}")]
-	ObjectFindExistingWithConversionError(
+	ObjectFindExistingWithConversion(
 		#[from] gix::object::find::existing::with_conversion::Error,
 	),
 
@@ -38,6 +38,14 @@ pub enum GixError {
 	///
 	#[error("gix::reference::head_tree_id::Error error: {0}")]
 	ReferenceHeadTreeId(#[from] gix::reference::head_tree_id::Error),
+
+	///
+	#[error("gix::reference::iter::Error error: {0}")]
+	ReferenceIter(#[from] gix::reference::iter::Error),
+
+	///
+	#[error("gix::reference::iter::init::Error error: {0}")]
+	ReferenceIterInit(#[from] gix::reference::iter::init::Error),
 
 	///
 	#[error("gix::revision::walk error: {0}")]
@@ -247,6 +255,18 @@ impl From<gix::reference::find::existing::Error> for Error {
 
 impl From<gix::reference::head_tree_id::Error> for Error {
 	fn from(error: gix::reference::head_tree_id::Error) -> Self {
+		Self::Gix(GixError::from(error))
+	}
+}
+
+impl From<gix::reference::iter::Error> for Error {
+	fn from(error: gix::reference::iter::Error) -> Self {
+		Self::Gix(GixError::from(error))
+	}
+}
+
+impl From<gix::reference::iter::init::Error> for Error {
+	fn from(error: gix::reference::iter::init::Error) -> Self {
 		Self::Gix(GixError::from(error))
 	}
 }

--- a/asyncgit/src/sync/commits_info.rs
+++ b/asyncgit/src/sync/commits_info.rs
@@ -96,6 +96,15 @@ impl From<gix::ObjectId> for CommitId {
 	}
 }
 
+impl From<gix::Commit<'_>> for CommitId {
+	fn from(commit: gix::Commit<'_>) -> Self {
+		#[allow(clippy::expect_used)]
+		let oid = Oid::from_bytes(commit.id().as_bytes()).expect("`Oid::from_bytes(commit.id().as_bytes())` is expected to never fail");
+
+		Self::new(oid)
+	}
+}
+
 impl From<CommitId> for gix::ObjectId {
 	fn from(id: CommitId) -> Self {
 		Self::from_bytes_or_panic(id.0.as_bytes())

--- a/asyncgit/src/sync/tags.rs
+++ b/asyncgit/src/sync/tags.rs
@@ -65,7 +65,6 @@ pub fn get_tags(repo_path: &RepoPath) -> Result<Tags> {
 	for mut reference in (platform.tags()?).flatten() {
 		let commit = reference.peel_to_commit().ok();
 		let tag = reference.peel_to_tag().ok();
-		let reference_name = reference.name().as_bstr();
 
 		if let Some(commit) = commit {
 			let name = tag
@@ -74,7 +73,9 @@ pub fn get_tags(repo_path: &RepoPath) -> Result<Tags> {
 					let tag_ref = tag.decode().ok();
 					tag_ref.map(|tag_ref| tag_ref.name.to_string())
 				})
-				.unwrap_or_else(|| reference_name[10..].to_string());
+				.unwrap_or_else(|| {
+					reference.name().shorten().to_string()
+				});
 			let annotation = tag.and_then(|tag| {
 				let tag_ref = tag.decode().ok();
 				tag_ref.map(|tag_ref| tag_ref.message.to_string())


### PR DESCRIPTION
This PR is a draft, currently intended for a discussion with @Byron about the part of the API to be used for getting a reference’s name. I intend to mark it as ready once I’ve figured out how to best use the existing APIs.

Update 2025-06-09: this PR is now ready for review.

This PR changes the following:

- It converts `get_tags` to use `gitoxide` under the hood.
- It seems the current implementation might have a bug. At least, the `gitoxide` version properly show an `@` symbol in the tags popup for annotated tags, something the `libgit` version doesn’t do. (I didn’t investigate this in depth, though.)

I followed the checklist:

- [x] I ran `make check` without errors
- [x] I tested the overall application
