### PR TITLE
Improve error message on config dir error

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -50,7 +50,10 @@ pub fn process_cmdline() -> Result<CliArgs> {
 
 	let confpath = get_app_config_path()?;
 	fs::create_dir_all(&confpath).with_context(|| {
-		format!("failed to write config to {}", confpath.display())
+		format!(
+			"failed to create config directory: {}",
+			confpath.display()
+		)
 	})?;
 	let theme = confpath.join(arg_theme);
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,5 +1,5 @@
 use crate::bug_report;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use asyncgit::sync::RepoPath;
 use clap::{
 	builder::ArgPredicate, crate_authors, crate_description,
@@ -49,7 +49,9 @@ pub fn process_cmdline() -> Result<CliArgs> {
 		.map_or_else(|| PathBuf::from("theme.ron"), PathBuf::from);
 
 	let confpath = get_app_config_path()?;
-	fs::create_dir_all(&confpath)?;
+	fs::create_dir_all(&confpath).with_context(|| {
+		format!("failed to write config to {}", confpath.display())
+	})?;
 	let theme = confpath.join(arg_theme);
 
 	let notify_watcher: bool =


### PR DESCRIPTION
This Pull Request closes #2683.

It changes the error message when the config and/or HOME directory is not writable from:
```
Error: Permission denied (os error 13)
```
to
```
Error: failed to write config to /home/sobczal/Dev/playground/test/.config/gitui

Caused by:
    Permission denied (os error 13)
```