### PR TITLE
Derive Default per clippy recommendation

### DIFF
--- a/asyncgit/src/sync/config.rs
+++ b/asyncgit/src/sync/config.rs
@@ -8,21 +8,16 @@ use super::{repository::repo, RepoPath};
 // see https://git-scm.com/docs/git-config#Documentation/git-config.txt-statusshowUntrackedFiles
 /// represents the `status.showUntrackedFiles` git config state
 #[derive(
-	Hash, Copy, Clone, PartialEq, Eq, Serialize, Deserialize,
+	Hash, Copy, Clone, Default, PartialEq, Eq, Serialize, Deserialize,
 )]
 pub enum ShowUntrackedFilesConfig {
 	///
+	#[default]
 	No,
 	///
 	Normal,
 	///
 	All,
-}
-
-impl Default for ShowUntrackedFilesConfig {
-	fn default() -> Self {
-		Self::No
-	}
 }
 
 impl ShowUntrackedFilesConfig {
@@ -68,19 +63,14 @@ pub fn untracked_files_config_repo(
 
 // see https://git-scm.com/docs/git-config#Documentation/git-config.txt-pushdefault
 /// represents `push.default` git config
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Default, Eq)]
 pub enum PushDefaultStrategyConfig {
 	Nothing,
 	Current,
 	Upstream,
+	#[default]
 	Simple,
 	Matching,
-}
-
-impl Default for PushDefaultStrategyConfig {
-	fn default() -> Self {
-		Self::Simple
-	}
 }
 
 impl<'a> TryFrom<&'a str> for PushDefaultStrategyConfig {

--- a/asyncgit/src/sync/diff.rs
+++ b/asyncgit/src/sync/diff.rs
@@ -22,9 +22,10 @@ use serde::{Deserialize, Serialize};
 use std::{cell::RefCell, fs, path::Path, rc::Rc};
 
 /// type of diff of a single line
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Copy, Clone, Default, PartialEq, Eq, Hash, Debug)]
 pub enum DiffLineType {
 	/// just surrounding line, no change
+	#[default]
 	None,
 	/// header of the hunk
 	Header,
@@ -44,12 +45,6 @@ impl From<git2::DiffLineType> for DiffLineType {
 			| git2::DiffLineType::Addition => Self::Add,
 			_ => Self::None,
 		}
-	}
-}
-
-impl Default for DiffLineType {
-	fn default() -> Self {
-		Self::None
 	}
 }
 

--- a/asyncgit/src/sync/remotes/push.rs
+++ b/asyncgit/src/sync/remotes/push.rs
@@ -98,18 +98,13 @@ impl AsyncProgress for ProgressNotification {
 }
 
 ///
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub enum PushType {
 	///
+	#[default]
 	Branch,
 	///
 	Tag,
-}
-
-impl Default for PushType {
-	fn default() -> Self {
-		Self::Branch
-	}
 }
 
 #[cfg(test)]

--- a/asyncgit/src/sync/status.rs
+++ b/asyncgit/src/sync/status.rs
@@ -104,20 +104,15 @@ pub struct StatusItem {
 }
 
 ///
-#[derive(Copy, Clone, Hash, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, Default, Hash, PartialEq, Eq, Debug)]
 pub enum StatusType {
 	///
+	#[default]
 	WorkingDir,
 	///
 	Stage,
 	///
 	Both,
-}
-
-impl Default for StatusType {
-	fn default() -> Self {
-		Self::WorkingDir
-	}
 }
 
 impl From<StatusType> for StatusShow {


### PR DESCRIPTION
This is another small PR addressing recommendations given by clippy on current `master`. It replaces a couple of manual `impl Default`s by `#[derive(Default)]` and `#[default]`.
