### PR TITLE
feat: Improve error messages for config and cache directory creation

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -49,7 +49,13 @@ pub fn process_cmdline() -> Result<CliArgs> {
 		.map_or_else(|| PathBuf::from("theme.ron"), PathBuf::from);
 
 	let confpath = get_app_config_path()?;
-	fs::create_dir_all(&confpath)?;
+	fs::create_dir_all(&confpath).map_err(|e| {
+		anyhow!(
+			"Failed to create config directory: {}\nError: {}",
+			confpath.display(),
+			e
+		)
+	})?;
 	let theme = confpath.join(arg_theme);
 
 	let notify_watcher: bool =
@@ -154,7 +160,13 @@ fn get_app_cache_path() -> Result<PathBuf> {
 		.ok_or_else(|| anyhow!("failed to find os cache dir."))?;
 
 	path.push("gitui");
-	fs::create_dir_all(&path)?;
+	fs::create_dir_all(&path).map_err(|e| {
+		anyhow!(
+			"Failed to create cache directory: {}\nError: {}",
+			path.display(),
+			e
+		)
+	})?;
 	Ok(path)
 }
 


### PR DESCRIPTION
## Summary

This PR improves error messages when GitUI fails to create config or cache directories due to permission issues or other filesystem errors. Instead of showing a generic error, users now receive clear, contextual information about which directory GitUI was trying to create.

## Problem

Fixes #2683 - Better error message if config (and/or HOME) directory is not writeable

Currently, when GitUI fails to create config directories due to permission issues, users see a generic error message:
```
Error: Permission denied (os error 13)
```

This provides no context about what GitUI was trying to do, making it difficult for users to understand and resolve the issue.

## Solution

The fix adds contextual error messages that clearly indicate:
1. **What GitUI was trying to do** (create config/cache directory)
2. **Which specific directory path** was involved
3. **The underlying system error**

### Before this change:
```
Error: Permission denied (os error 13)
```

### After this change:
```
Failed to create config directory: /home/user/.config/gitui
Error: Permission denied (os error 13)
```

```
Failed to create cache directory: /home/user/.cache/gitui  
Error: Permission denied (os error 13)
```

## Implementation

The changes are minimal and focused:

**In `process_cmdline()` (line 52-58):**
```rust
fs::create_dir_all(&confpath).map_err(|e| {
    anyhow!(
        "Failed to create config directory: {}\nError: {}",
        confpath.display(),
        e
    )
})?;
```

**In `get_app_cache_path()` (line 163-169):**
```rust
fs::create_dir_all(&path).map_err(|e| {
    anyhow!(
        "Failed to create cache directory: {}\nError: {}",
        path.display(),
        e
    )
})?;
```

## Testing

- ✅ Code compiles without errors
- ✅ No breaking changes to existing functionality
- ✅ Error messages provide clear context for debugging
- ✅ Maintains the same error propagation behavior

## Benefits

1. **Better user experience** - Users can immediately identify the problematic directory
2. **Easier troubleshooting** - No need to use `strace` or similar tools to debug permission issues
3. **Consistent error reporting** - Follows the pattern of providing context with system errors
4. **Non-breaking change** - Error handling behavior remains the same, only the message is improved

This addresses the exact issue described in #2683 where users had to resort to using `strace` to identify which directory was causing permission problems.

🤖 Generated with [Claude Code](https://claude.ai/code)