### PR TITLE
Fix all mismatched_lifetime_syntaxes warnings

### DIFF
--- a/asyncgit/src/sync/remotes/mod.rs
+++ b/asyncgit/src/sync/remotes/mod.rs
@@ -120,7 +120,7 @@ pub fn get_default_remote(repo_path: &RepoPath) -> Result<String> {
 /// and Err if there was a problem finding the branch
 fn get_current_branch(
 	repo: &Repository,
-) -> Result<Option<git2::Branch>> {
+) -> Result<Option<git2::Branch<'_>>> {
 	for b in repo.branches(None)? {
 		let branch = b?.0;
 		if branch.is_head() {

--- a/asyncgit/src/sync/reword.rs
+++ b/asyncgit/src/sync/reword.rs
@@ -62,7 +62,7 @@ pub fn reword(
 /// and Err if there was a problem finding the branch
 fn get_current_branch(
 	repo: &Repository,
-) -> Result<Option<git2::Branch>> {
+) -> Result<Option<git2::Branch<'_>>> {
 	for b in repo.branches(None)? {
 		let branch = b?.0;
 		if branch.is_head() {

--- a/src/components/commit_details/compare_details.rs
+++ b/src/components/commit_details/compare_details.rs
@@ -58,7 +58,7 @@ impl CompareDetailsComponent {
 		});
 	}
 
-	fn get_commit_text(&self, data: &CommitDetails) -> Vec<Line> {
+	fn get_commit_text(&self, data: &CommitDetails) -> Vec<Line<'_>> {
 		let mut res = vec![
 			Line::from(vec![
 				style_detail(&self.theme, &Detail::Author),

--- a/src/components/commit_details/details.rs
+++ b/src/components/commit_details/details.rs
@@ -136,7 +136,7 @@ impl DetailsComponent {
 		&self,
 		width: usize,
 		height: usize,
-	) -> Vec<Line> {
+	) -> Vec<Line<'_>> {
 		let (wrapped_title, wrapped_message) =
 			Self::get_wrapped_lines(self.data.as_ref(), width);
 
@@ -156,7 +156,7 @@ impl DetailsComponent {
 	}
 
 	#[allow(clippy::too_many_lines)]
-	fn get_text_info(&self) -> Vec<Line> {
+	fn get_text_info(&self) -> Vec<Line<'_>> {
 		self.data.as_ref().map_or_else(Vec::new, |data| {
 			let mut res = vec![
 				Line::from(vec![

--- a/src/components/commitlist.rs
+++ b/src/components/commitlist.rs
@@ -565,7 +565,7 @@ impl CommitList {
 		Line::from(txt)
 	}
 
-	fn get_text(&self, height: usize, width: usize) -> Vec<Line> {
+	fn get_text(&self, height: usize, width: usize) -> Vec<Line<'_>> {
 		let selection = self.relative_selection();
 
 		let mut txt: Vec<Line> = Vec::with_capacity(height);

--- a/src/components/diff.rs
+++ b/src/components/diff.rs
@@ -324,7 +324,7 @@ impl DiffComponent {
 		None
 	}
 
-	fn get_text(&self, width: u16, height: u16) -> Vec<Line> {
+	fn get_text(&self, width: u16, height: u16) -> Vec<Line<'_>> {
 		if let Some(diff) = &self.diff {
 			return if diff.hunks.is_empty() {
 				self.get_text_binary(diff)
@@ -387,7 +387,7 @@ impl DiffComponent {
 		vec![]
 	}
 
-	fn get_text_binary(&self, diff: &FileDiff) -> Vec<Line> {
+	fn get_text_binary(&self, diff: &FileDiff) -> Vec<Line<'_>> {
 		let is_positive = diff.size_delta >= 0;
 		let delta_byte_size =
 			ByteSize::b(diff.size_delta.unsigned_abs());

--- a/src/components/status_tree.rs
+++ b/src/components/status_tree.rs
@@ -223,7 +223,7 @@ impl StatusTreeComponent {
 	/// allowing folders to be folded up if they are alone in their directory
 	fn build_vec_text_draw_info_for_drawing(
 		&self,
-	) -> (Vec<TextDrawInfo>, usize, usize) {
+	) -> (Vec<TextDrawInfo<'_>>, usize, usize) {
 		let mut should_skip_over: usize = 0;
 		let mut selection_offset: usize = 0;
 		let mut selection_offset_visible: usize = 0;

--- a/src/popups/blame_file.rs
+++ b/src/popups/blame_file.rs
@@ -529,7 +529,7 @@ impl BlameFilePopup {
 	}
 
 	///
-	fn get_rows(&self, width: usize) -> Vec<Row> {
+	fn get_rows(&self, width: usize) -> Vec<Row<'_>> {
 		self.blame
 			.as_ref()
 			.and_then(|blame| blame.result())
@@ -643,7 +643,7 @@ impl BlameFilePopup {
 		&self,
 		width: usize,
 		blame_hunk: Option<&BlameHunk>,
-	) -> Vec<Cell> {
+	) -> Vec<Cell<'_>> {
 		let commit_hash = blame_hunk.map_or_else(
 			|| NO_COMMIT_ID.into(),
 			|hunk| hunk.commit_id.get_short_string(),

--- a/src/popups/branchlist.rs
+++ b/src/popups/branchlist.rs
@@ -473,7 +473,7 @@ impl BranchListPopup {
 		theme: &SharedTheme,
 		width_available: u16,
 		height: usize,
-	) -> Text {
+	) -> Text<'_> {
 		const UPSTREAM_SYMBOL: char = '\u{2191}';
 		const TRACKING_SYMBOL: char = '\u{2193}';
 		const HEAD_SYMBOL: char = '*';

--- a/src/popups/file_revlog.rs
+++ b/src/popups/file_revlog.rs
@@ -263,7 +263,7 @@ impl FileRevlogPopup {
 		)
 	}
 
-	fn get_rows(&self, now: DateTime<Local>) -> Vec<Row> {
+	fn get_rows(&self, now: DateTime<Local>) -> Vec<Row<'_>> {
 		self.items
 			.iter()
 			.map(|entry| {

--- a/src/popups/help.rs
+++ b/src/popups/help.rs
@@ -211,7 +211,7 @@ impl HelpPopup {
 		}
 	}
 
-	fn get_text(&self) -> Vec<Line> {
+	fn get_text(&self) -> Vec<Line<'_>> {
 		let mut txt: Vec<Line> = Vec::new();
 
 		let mut processed = 0_u16;

--- a/src/popups/log_search.rs
+++ b/src/popups/log_search.rs
@@ -164,7 +164,7 @@ impl LogSearchPopupPopup {
 		}
 	}
 
-	fn get_text_options(&self) -> Vec<Line> {
+	fn get_text_options(&self) -> Vec<Line<'_>> {
 		let x_summary =
 			if self.options.0.contains(SearchFields::MESSAGE_SUMMARY)
 			{

--- a/src/popups/options.rs
+++ b/src/popups/options.rs
@@ -51,7 +51,7 @@ impl OptionsPopup {
 		}
 	}
 
-	fn get_text(&self, width: u16) -> Vec<Line> {
+	fn get_text(&self, width: u16) -> Vec<Line<'_>> {
 		let mut txt: Vec<Line> = Vec::with_capacity(10);
 
 		self.add_status(&mut txt, width);

--- a/src/popups/remotelist.rs
+++ b/src/popups/remotelist.rs
@@ -230,7 +230,7 @@ impl RemoteListPopup {
 		theme: &SharedTheme,
 		width_available: u16,
 		height: usize,
-	) -> Text {
+	) -> Text<'_> {
 		const THREE_DOTS: &str = "...";
 		const THREE_DOTS_LENGTH: usize = THREE_DOTS.len(); // "..."
 

--- a/src/popups/reset.rs
+++ b/src/popups/reset.rs
@@ -67,7 +67,7 @@ impl ResetPopup {
 		}
 	}
 
-	fn get_text(&self, _width: u16) -> Vec<Line> {
+	fn get_text(&self, _width: u16) -> Vec<Line<'_>> {
 		let mut txt: Vec<Line> = Vec::with_capacity(10);
 
 		txt.push(Line::from(vec![

--- a/src/popups/submodules.rs
+++ b/src/popups/submodules.rs
@@ -336,7 +336,7 @@ impl SubmodulesListPopup {
 		theme: &SharedTheme,
 		width_available: u16,
 		height: usize,
-	) -> Text {
+	) -> Text<'_> {
 		const THREE_DOTS: &str = "...";
 		const THREE_DOTS_LENGTH: usize = THREE_DOTS.len(); // "..."
 		const COMMIT_HASH_LENGTH: usize = 8;
@@ -393,7 +393,7 @@ impl SubmodulesListPopup {
 		Text::from(txt)
 	}
 
-	fn get_info_text(&self, theme: &SharedTheme) -> Text {
+	fn get_info_text(&self, theme: &SharedTheme) -> Text<'_> {
 		self.selected_entry().map_or_else(
 			Text::default,
 			|submodule| {
@@ -442,7 +442,7 @@ impl SubmodulesListPopup {
 		)
 	}
 
-	fn get_local_info_text(&self, theme: &SharedTheme) -> Text {
+	fn get_local_info_text(&self, theme: &SharedTheme) -> Text<'_> {
 		let mut spans = vec![
 			Line::from(vec![Span::styled(
 				"Current:",

--- a/src/popups/taglist.rs
+++ b/src/popups/taglist.rs
@@ -433,14 +433,14 @@ impl TagListPopup {
 	}
 
 	///
-	fn get_rows(&self) -> Vec<Row> {
+	fn get_rows(&self) -> Vec<Row<'_>> {
 		self.tags.as_ref().map_or_else(Vec::new, |tags| {
 			tags.iter().map(|tag| self.get_row(tag)).collect()
 		})
 	}
 
 	///
-	fn get_row(&self, tag: &TagWithMetadata) -> Row {
+	fn get_row(&self, tag: &TagWithMetadata) -> Row<'_> {
 		const UPSTREAM_SYMBOL: &str = "\u{2191}";
 		const ATTACHMENT_SYMBOL: &str = "@";
 		const EMPTY_SYMBOL: &str = " ";

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -423,7 +423,7 @@ pub fn copy_success(s: &str) -> String {
 	format!("{POPUP_SUCCESS_COPY} \"{s}\"")
 }
 
-pub fn ellipsis_trim_start(s: &str, width: usize) -> Cow<str> {
+pub fn ellipsis_trim_start(s: &str, width: usize) -> Cow<'_, str> {
 	if s.width() <= width {
 		Cow::Borrowed(s)
 	} else {

--- a/src/tabs/stashing.rs
+++ b/src/tabs/stashing.rs
@@ -98,7 +98,7 @@ impl Stashing {
 		Ok(())
 	}
 
-	fn get_option_text(&self) -> Vec<Line> {
+	fn get_option_text(&self) -> Vec<Line<'_>> {
 		let bracket_open = Span::raw(Cow::from("["));
 		let bracket_close = Span::raw(Cow::from("]"));
 		let option_on =


### PR DESCRIPTION
Since Rust 1.89.0, a warning is emitted by default when the lifetime of the return type is implicitly elided but matches an input parameter of the function.

rustc tells us how to fix it (but weirdly enough there is no `cargo fix` for it), so let’s do that, it makes the elided lifetime much more evident anyway.

I followed the checklist:
- [ ] I added unittests (not relevant)
- [x] I ran `make check` without errors
- [x] I tested the overall application
- [ ] I added an appropriate item to the changelog (not relevant)