### PR TITLE
Feat adjusting size status tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * execute git-hooks directly if possible (on *nix) else use sh instead of bash (without reading SHELL variable) [[@Joshix](https://github.com/Joshix-1)] ([#2483](https://github.com/extrawurst/gitui/pull/2483))
 
 ### Added
+* Added dynamic layout resizing in the status view (Alt+Arrow keys to adjust splits)[[@Hari-Oggy](https://github.com/Hari-Oggy)] ([#2669](https://github.com/extrawurst/gitui/issues/2669))
 * Files and status tab support pageUp and pageDown  [[@fatpandac](https://github.com/fatpandac)] ([#1951](https://github.com/extrawurst/gitui/issues/1951))
 * support loading custom syntax highlighting themes from a file [[@acuteenvy](https://github.com/acuteenvy)] ([#2565](https://github.com/gitui-org/gitui/pull/2565))
 * Select syntax highlighting theme out of the defaults from syntect [[@vasilismanol](https://github.com/vasilismanol)] ([#1931](https://github.com/extrawurst/gitui/issues/1931))

--- a/src/keys/key_list.rs
+++ b/src/keys/key_list.rs
@@ -128,6 +128,10 @@ pub struct KeysList {
 	pub commit_history_next: GituiKeyEvent,
 	pub commit: GituiKeyEvent,
 	pub newline: GituiKeyEvent,
+	pub alt_up: GituiKeyEvent,
+	pub alt_down: GituiKeyEvent,
+	pub alt_left: GituiKeyEvent,
+	pub alt_right: GituiKeyEvent,
 }
 
 #[rustfmt::skip]
@@ -157,6 +161,10 @@ impl Default for KeysList {
 			end: GituiKeyEvent::new(KeyCode::End,  KeyModifiers::empty()),
 			move_up: GituiKeyEvent::new(KeyCode::Up,  KeyModifiers::empty()),
 			move_down: GituiKeyEvent::new(KeyCode::Down,  KeyModifiers::empty()),
+			alt_up: GituiKeyEvent::new(KeyCode::Up,KeyModifiers::ALT),
+			alt_down:GituiKeyEvent::new(KeyCode::Down,KeyModifiers::ALT),
+			alt_left: GituiKeyEvent::new(KeyCode::Left,KeyModifiers::ALT),
+			alt_right:GituiKeyEvent::new(KeyCode::Right,KeyModifiers::ALT),
 			popup_up: GituiKeyEvent::new(KeyCode::Up,  KeyModifiers::empty()),
 			popup_down: GituiKeyEvent::new(KeyCode::Down,  KeyModifiers::empty()),
 			page_down: GituiKeyEvent::new(KeyCode::PageDown,  KeyModifiers::empty()),

--- a/src/tabs/status.rs
+++ b/src/tabs/status.rs
@@ -81,6 +81,9 @@ pub struct Status {
 	git_action_executed: bool,
 	options: SharedOptions,
 	key_config: SharedKeyConfig,
+	horizontal_split: (u16, u16), // Left vs Right
+	vertical_split_wd: (u16, u16), // Top vs Bottom when WorkingDir
+	vertical_split_index: (u16, u16),
 }
 
 impl DrawableComponent for Status {
@@ -112,8 +115,12 @@ impl DrawableComponent for Status {
 					]
 				} else {
 					[
-						Constraint::Percentage(50),
-						Constraint::Percentage(50),
+						Constraint::Percentage(
+							self.horizontal_split.0,
+						),
+						Constraint::Percentage(
+							self.horizontal_split.1,
+						),
 					]
 				}
 				.as_ref(),
@@ -125,13 +132,21 @@ impl DrawableComponent for Status {
 			.constraints(
 				if self.diff_target == DiffTarget::WorkingDir {
 					[
-						Constraint::Percentage(60),
-						Constraint::Percentage(40),
+						Constraint::Percentage(
+							self.vertical_split_wd.0,
+						),
+						Constraint::Percentage(
+							self.vertical_split_wd.1,
+						),
 					]
 				} else {
 					[
-						Constraint::Percentage(40),
-						Constraint::Percentage(60),
+						Constraint::Percentage(
+							self.vertical_split_index.0,
+						),
+						Constraint::Percentage(
+							self.vertical_split_index.1,
+						),
 					]
 				}
 				.as_ref(),
@@ -200,6 +215,9 @@ impl Status {
 			key_config: env.key_config.clone(),
 			options: env.options.clone(),
 			repo: env.repo.clone(),
+			horizontal_split: (50, 50),
+			vertical_split_wd: (60, 40),
+			vertical_split_index: (40, 60),
 		}
 	}
 
@@ -946,6 +964,49 @@ impl Component for Status {
 					self.key_config.keys.view_submodules,
 				) {
 					self.queue.push(InternalEvent::ViewSubmodules);
+					Ok(EventState::Consumed)
+				} else if key_match(k, self.key_config.keys.alt_left)
+				{
+					if self.horizontal_split.0 > 10 {
+						self.horizontal_split.0 -= 5;
+						self.horizontal_split.1 += 5;
+					}
+					Ok(EventState::Consumed)
+				} else if key_match(k, self.key_config.keys.alt_right)
+				{
+					if self.horizontal_split.1 > 10 {
+						self.horizontal_split.0 += 5;
+						self.horizontal_split.1 -= 5;
+					}
+					Ok(EventState::Consumed)
+				} else if key_match(k, self.key_config.keys.alt_up) {
+					let (top, bottom) = match self.diff_target {
+						DiffTarget::WorkingDir => {
+							&mut self.vertical_split_wd
+						}
+						DiffTarget::Stage => {
+							&mut self.vertical_split_index
+						}
+					};
+					if *bottom > 10 {
+						*top += 5;
+						*bottom -= 5;
+					}
+					Ok(EventState::Consumed)
+				} else if key_match(k, self.key_config.keys.alt_down)
+				{
+					let (top, bottom) = match self.diff_target {
+						DiffTarget::WorkingDir => {
+							&mut self.vertical_split_wd
+						}
+						DiffTarget::Stage => {
+							&mut self.vertical_split_index
+						}
+					};
+					if *top > 10 {
+						*top -= 5;
+						*bottom += 5;
+					}
 					Ok(EventState::Consumed)
 				} else {
 					Ok(EventState::NotConsumed)


### PR DESCRIPTION
<!---
Thank you for contributing to GitUI! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #{2669}.

It changes the following:
- Added dynamic layout resizing in the status view
- Introduced new keybindings (Alt+Arrow keys) to adjust horizontal and vertical splits
- Replaced hardcoded `Constraint::Percentage` values with configurable state

I followed the checklist:
- [ ] I added unittests
- [X] I ran `make check` without errors
- [X] I tested the overall application
- [X] I added an appropriate item to the changelog
[gituidynamicsizeworking.webm](https://github.com/user-attachments/assets/97c84e27-cbc5-47f0-b044-2bc8bc1715a0)
