### PR TITLE
add OpenHarmony (OHOS) target support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,12 @@ make a contribution.
 
 ## Cross-compiling for OpenHarmony
 
-GitUI can be built for OpenHarmony (target `aarch64-unknown-linux-ohos`). This requires the [OpenHarmony SDK](https://www.openharmony.cn/) native toolchain.
+GitUI can be built for OpenHarmony (target `aarch64-unknown-linux-ohos`). This requires the OpenHarmony SDK native toolchain.
+
+Download the SDK command-line tools from [HarmonyOS Developer](https://developer.huawei.com/consumer/cn/download/command-line-tools-for-hmos). After installation, the default SDK path is typically:
+
+- Linux: `~/command-line-tools/sdk/default/openharmony`
+- macOS: `~/Library/command-line-tools/sdk/default/openharmony`
 
 First, install the `aarch64-unknown-linux-ohos` Rust target:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,5 +22,34 @@ good first issue, you can take a look at [issues labelled with
 too much context so that people not familiar with the codebase yet can still
 make a contribution.
 
+## Cross-compiling for OpenHarmony
+
+GitUI can be built for OpenHarmony (target `aarch64-unknown-linux-ohos`). This requires the [OpenHarmony SDK](https://www.openharmony.cn/) native toolchain.
+
+First, install the `aarch64-unknown-linux-ohos` Rust target:
+
+```sh
+rustup target add aarch64-unknown-linux-ohos
+```
+
+Set the following environment variables (adjust paths to your OHOS SDK location):
+
+```sh
+export OHOS_SDK=/path/to/ohos-sdk
+export CC_aarch64_unknown_linux_ohos="$OHOS_SDK/native/llvm/bin/clang"
+export CXX_aarch64_unknown_linux_ohos="$OHOS_SDK/native/llvm/bin/clang++"
+export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER="$OHOS_SDK/native/llvm/bin/clang"
+export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_AR="$OHOS_SDK/native/llvm/bin/llvm-ar"
+export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_RUSTFLAGS="-C link-arg=--sysroot=$OHOS_SDK/native/sysroot -C link-arg=-L$OHOS_SDK/native/sysroot/usr/lib/aarch64-linux-ohos -C link-arg=-Wl,--allow-multiple-definition -C link-arg=-Wl,--undefined-version -C link-arg=-Wl,--defsym=__xpg_strerror_r=0"
+```
+
+Then build:
+
+```sh
+cargo build --target aarch64-unknown-linux-ohos --release
+```
+
+> **Note:** On OpenHarmony the user/process model is sandbox-based. GitUI automatically disables libgit2's owner validation on OHOS targets to avoid spurious "not owned by current user" errors.
+
 [discord-server]: https://discord.gg/rZv4uxSQx3
 [good-first-issues]: https://github.com/gitui-org/gitui/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22

--- a/asyncgit/src/revlog.rs
+++ b/asyncgit/src/revlog.rs
@@ -1,11 +1,12 @@
 use crate::{
 	error::Result,
 	sync::{
-		gix_repo, repo, CommitId, LogWalker, LogWalkerWithoutFilter,
-		RepoPath, SharedCommitFilterFn,
+		repo, CommitId, LogWalker, RepoPath, SharedCommitFilterFn,
 	},
 	AsyncGitNotification, Error,
 };
+#[cfg(not(target_env = "ohos"))]
+use crate::sync::{gix_repo, LogWalkerWithoutFilter};
 use crossbeam_channel::Sender;
 use scopetime::scope_time;
 use std::{
@@ -200,25 +201,45 @@ impl AsyncLog {
 		sender: &Sender<AsyncGitNotification>,
 		filter: Option<SharedCommitFilterFn>,
 	) -> Result<()> {
-		filter.map_or_else(
-			|| {
-				Self::fetch_helper_without_filter(
-					repo_path,
-					arc_current,
-					arc_background,
-					sender,
-				)
-			},
-			|filter| {
-				Self::fetch_helper_with_filter(
-					repo_path,
-					arc_current,
-					arc_background,
-					sender,
-					filter,
-				)
-			},
-		)
+		#[cfg(target_env = "ohos")]
+		{
+			Self::fetch_helper_with_filter(
+				repo_path,
+				arc_current,
+				arc_background,
+				sender,
+				filter.unwrap_or_else(|| {
+					Arc::new(Box::new(
+						|_: &git2::Repository, _: &CommitId| {
+							Ok(true)
+						},
+					))
+				}),
+			)
+		}
+
+		#[cfg(not(target_env = "ohos"))]
+		{
+			filter.map_or_else(
+				|| {
+					Self::fetch_helper_without_filter(
+						repo_path,
+						arc_current,
+						arc_background,
+						sender,
+					)
+				},
+				|filter| {
+					Self::fetch_helper_with_filter(
+						repo_path,
+						arc_current,
+						arc_background,
+						sender,
+						filter,
+					)
+				},
+			)
+		}
 	}
 
 	fn fetch_helper_with_filter(
@@ -265,6 +286,7 @@ impl AsyncLog {
 		Ok(())
 	}
 
+	#[cfg(not(target_env = "ohos"))]
 	fn fetch_helper_without_filter(
 		repo_path: &RepoPath,
 		arc_current: &Arc<Mutex<AsyncLogResult>>,

--- a/asyncgit/src/sync/commits_info.rs
+++ b/asyncgit/src/sync/commits_info.rs
@@ -5,9 +5,11 @@ use crate::{
 	error::Result,
 	sync::{
 		commit_details::get_author_of_commit,
-		repository::{gix_repo, repo},
+		repository::repo,
 	},
 };
+#[cfg(not(target_env = "ohos"))]
+use crate::sync::repository::gix_repo;
 use git2::{Commit, Error, Oid};
 use scopetime::scope_time;
 use unicode_truncate::UnicodeTruncateStr;
@@ -169,27 +171,44 @@ pub fn get_commit_info(
 ) -> Result<CommitInfo> {
 	scope_time!("get_commit_info");
 
-	let repo: gix::Repository = gix_repo(repo_path)?;
-	let mailmap = repo.open_mailmap();
+	#[cfg(target_env = "ohos")]
+	{
+		let mut infos = get_commits_info(
+			repo_path,
+			&[*commit_id],
+			usize::MAX,
+		)?;
+		return infos.pop().ok_or_else(|| {
+			crate::error::Error::Generic(
+				"commit not found".into(),
+			)
+		});
+	}
 
-	let commit = repo.find_commit(*commit_id)?;
-	let commit_ref = commit.decode()?;
+	#[cfg(not(target_env = "ohos"))]
+	{
+		let repo: gix::Repository = gix_repo(repo_path)?;
+		let mailmap = repo.open_mailmap();
 
-	let message = gix_get_message(&commit_ref, None);
+		let commit = repo.find_commit(*commit_id)?;
+		let commit_ref = commit.decode()?;
 
-	let author = commit_ref.author()?;
+		let message = gix_get_message(&commit_ref, None);
 
-	let author = mailmap.try_resolve(author).map_or_else(
-		|| author.name.into(),
-		|signature| signature.name,
-	);
+		let author = commit_ref.author()?;
 
-	Ok(CommitInfo {
-		message,
-		author: author.to_string(),
-		time: commit_ref.time()?.seconds,
-		id: commit.id().detach().into(),
-	})
+		let author = mailmap.try_resolve(author).map_or_else(
+			|| author.name.into(),
+			|signature| signature.name,
+		);
+
+		Ok(CommitInfo {
+			message,
+			author: author.to_string(),
+			time: commit_ref.time()?.seconds,
+			id: commit.id().detach().into(),
+		})
+	}
 }
 
 /// if `message_limit` is set the message will be
@@ -212,6 +231,7 @@ pub fn get_message(
 
 /// if `message_limit` is set the message will be
 /// limited to the first line and truncated to fit
+#[cfg(not(target_env = "ohos"))]
 pub fn gix_get_message(
 	commit_ref: &gix::objs::CommitRef,
 	message_limit: Option<usize>,

--- a/asyncgit/src/sync/mod.rs
+++ b/asyncgit/src/sync/mod.rs
@@ -85,7 +85,9 @@ pub use remotes::{
 	get_remote_url, get_remotes, push::AsyncProgress, rename_remote,
 	tags::PushTagsProgress, update_remote_url, validate_remote_name,
 };
-pub(crate) use repository::{gix_repo, repo};
+#[cfg(not(target_env = "ohos"))]
+pub(crate) use repository::gix_repo;
+pub(crate) use repository::repo;
 pub use repository::{RepoPath, RepoPathRef};
 pub use reset::{reset_repo, reset_stage, reset_workdir};
 pub use reword::reword;

--- a/asyncgit/src/sync/repository.rs
+++ b/asyncgit/src/sync/repository.rs
@@ -7,6 +7,22 @@ use git2::{Repository, RepositoryOpenFlags};
 
 use crate::error::Result;
 
+#[cfg(target_env = "ohos")]
+use std::sync::Once;
+
+#[cfg(target_env = "ohos")]
+static INIT_OHOS: Once = Once::new();
+
+#[cfg(target_env = "ohos")]
+pub(crate) fn init_ohos_owner_validation() {
+	INIT_OHOS.call_once(|| {
+		#[allow(unsafe_code)]
+		unsafe {
+			git2::opts::set_verify_owner_validation(false).ok();
+		}
+	});
+}
+
 ///
 pub type RepoPathRef = RefCell<RepoPath>;
 
@@ -55,6 +71,9 @@ impl From<&str> for RepoPath {
 }
 
 pub fn repo(repo_path: &RepoPath) -> Result<Repository> {
+	#[cfg(target_env = "ohos")]
+	init_ohos_owner_validation();
+
 	let repo = Repository::open_ext(
 		repo_path.gitpath(),
 		RepositoryOpenFlags::FROM_ENV,

--- a/asyncgit/src/sync/repository.rs
+++ b/asyncgit/src/sync/repository.rs
@@ -87,6 +87,7 @@ pub fn repo(repo_path: &RepoPath) -> Result<Repository> {
 	Ok(repo)
 }
 
+#[cfg(not(target_env = "ohos"))]
 pub fn gix_repo(repo_path: &RepoPath) -> Result<gix::Repository> {
 	let mut repo: gix::Repository = gix::ThreadSafeRepository::discover_with_environment_overrides(
 		repo_path.gitpath(),

--- a/asyncgit/src/sync/status.rs
+++ b/asyncgit/src/sync/status.rs
@@ -4,9 +4,11 @@ use crate::{
 	error::Result,
 	sync::{
 		config::untracked_files_config_repo,
-		repository::{gix_repo, repo},
+		repository::repo,
 	},
 };
+#[cfg(not(target_env = "ohos"))]
+use crate::sync::repository::gix_repo;
 use git2::{Delta, Status, StatusOptions, StatusShow};
 use scopetime::scope_time;
 use std::path::Path;
@@ -60,6 +62,38 @@ impl From<gix::diff::index::ChangeRef<'_, '_>> for StatusItemType {
 			ChangeRef::Deletion { .. } => Self::Deleted,
 			ChangeRef::Modification { .. }
 			| ChangeRef::Rewrite { .. } => Self::Modified,
+		}
+	}
+}
+
+impl StatusItemType {
+	/// Convert from worktree-only status flags.
+	pub fn from_wt(s: Status) -> Self {
+		if s.is_wt_new() {
+			Self::New
+		} else if s.is_wt_deleted() {
+			Self::Deleted
+		} else if s.is_wt_renamed() {
+			Self::Renamed
+		} else if s.is_wt_typechange() {
+			Self::Typechange
+		} else {
+			Self::Modified
+		}
+	}
+
+	/// Convert from index-only status flags.
+	pub fn from_index(s: Status) -> Self {
+		if s.is_index_new() {
+			Self::New
+		} else if s.is_index_deleted() {
+			Self::Deleted
+		} else if s.is_index_renamed() {
+			Self::Renamed
+		} else if s.is_index_typechange() {
+			Self::Typechange
+		} else {
+			Self::Modified
 		}
 	}
 }
@@ -168,6 +202,7 @@ impl From<ShowUntrackedFilesConfig> for gix::status::UntrackedFiles {
 }
 
 /// guarantees sorting
+#[cfg(not(target_env = "ohos"))]
 pub fn get_status(
 	repo_path: &RepoPath,
 	status_type: StatusType,
@@ -275,6 +310,91 @@ pub fn get_status(
 					res.push(StatusItem { path, status });
 				}
 			}
+		}
+	}
+
+	res.sort_by(|a, b| {
+		Path::new(a.path.as_str()).cmp(Path::new(b.path.as_str()))
+	});
+
+	Ok(res)
+}
+
+/// git2-based status for OpenHarmony targets.
+/// On OHOS, gix-odb's slot map for pack indices can overflow
+/// (InsufficientSlots), so we fall back to git2.
+#[cfg(target_env = "ohos")]
+pub fn get_status(
+	repo_path: &RepoPath,
+	status_type: StatusType,
+	show_untracked: Option<ShowUntrackedFilesConfig>,
+) -> Result<Vec<StatusItem>> {
+	scope_time!("get_status");
+
+	let repo = repo(repo_path)?;
+
+	let show_untracked = if let Some(config) = show_untracked {
+		config
+	} else {
+		untracked_files_config_repo(&repo)?
+	};
+
+	let mut options = StatusOptions::default();
+	options
+		.show(status_type.into())
+		.update_index(true)
+		.include_untracked(show_untracked.include_untracked())
+		.renames_head_to_index(true)
+		.recurse_untracked_dirs(
+			show_untracked.recurse_untracked_dirs(),
+		);
+
+	let statuses = repo.statuses(Some(&mut options))?;
+
+	let mut res = Vec::with_capacity(statuses.len());
+
+	for entry in statuses.iter() {
+		let Some(path) = entry.path() else {
+			continue;
+		};
+
+		let status = entry.status();
+
+		if status_type == StatusType::Both {
+			if status.is_wt_new()
+				|| status.is_wt_deleted()
+				|| status.is_wt_modified()
+				|| status.is_wt_renamed()
+				|| status.is_wt_typechange()
+			{
+				res.push(StatusItem {
+					path: path.to_string(),
+					status: StatusItemType::from_wt(status),
+				});
+			}
+			if status.is_index_new()
+				|| status.is_index_deleted()
+				|| status.is_index_modified()
+				|| status.is_index_renamed()
+				|| status.is_index_typechange()
+			{
+				res.push(StatusItem {
+					path: path.to_string(),
+					status: StatusItemType::from_index(status),
+				});
+			}
+			if status.is_conflicted() {
+				res.push(StatusItem {
+					path: path.to_string(),
+					status: StatusItemType::Conflicted,
+				});
+			}
+		} else {
+			let status: StatusItemType = status.into();
+			res.push(StatusItem {
+				path: path.to_string(),
+				status,
+			});
 		}
 	}
 

--- a/asyncgit/src/sync/status.rs
+++ b/asyncgit/src/sync/status.rs
@@ -354,7 +354,7 @@ pub fn get_status(
 	let mut res = Vec::with_capacity(statuses.len());
 
 	for entry in statuses.iter() {
-		let Some(path) = entry.path() else {
+		let Ok(path) = entry.path() else {
 			continue;
 		};
 

--- a/asyncgit/src/sync/tags.rs
+++ b/asyncgit/src/sync/tags.rs
@@ -1,8 +1,10 @@
 use super::{get_commits_info, CommitId, RepoPath};
 use crate::{
 	error::Result,
-	sync::{gix_repo, repository::repo},
+	sync::repository::repo,
 };
+#[cfg(not(target_env = "ohos"))]
+use crate::sync::gix_repo;
 use scopetime::scope_time;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
@@ -49,6 +51,7 @@ pub struct TagWithMetadata {
 static MAX_MESSAGE_WIDTH: usize = 100;
 
 /// returns `Tags` type filled with all tags found in repo
+#[cfg(not(target_env = "ohos"))]
 pub fn get_tags(repo_path: &RepoPath) -> Result<Tags> {
 	scope_time!("get_tags");
 
@@ -80,6 +83,48 @@ pub fn get_tags(repo_path: &RepoPath) -> Result<Tags> {
 			};
 
 			adder(commit.into(), Tag { name, annotation });
+		}
+	}
+
+	Ok(res)
+}
+
+/// git2-based tag listing for OpenHarmony targets.
+/// On OHOS, gix-odb's slot map for pack indices can overflow
+/// (InsufficientSlots), so we fall back to git2.
+#[cfg(target_env = "ohos")]
+pub fn get_tags(repo_path: &RepoPath) -> Result<Tags> {
+	scope_time!("get_tags");
+
+	let mut res = Tags::new();
+	let mut adder = |key, value: Tag| {
+		if let Some(key) = res.get_mut(&key) {
+			key.push(value);
+		} else {
+			res.insert(key, vec![value]);
+		}
+	};
+
+	let repo = repo(repo_path)?;
+	let tag_names = repo.tag_names(None)?;
+
+	for name in tag_names.iter().flatten() {
+		let reference = match repo.find_reference(
+			&format!("refs/tags/{name}"),
+		) {
+			Ok(r) => r,
+			Err(_) => continue,
+		};
+
+		let target = reference.target();
+		let tag = reference.peel_to_tag();
+
+		if let (Some(commit_id), Ok(tag)) = (target, tag) {
+			let name = tag.name().unwrap_or(name).to_string();
+			let annotation = tag.message().map(|s| s.to_string());
+			adder(commit_id.into(), Tag { name, annotation });
+		} else if let Some(commit_id) = target {
+			adder(commit_id.into(), Tag::new(name));
 		}
 	}
 

--- a/asyncgit/src/sync/tags.rs
+++ b/asyncgit/src/sync/tags.rs
@@ -109,6 +109,8 @@ pub fn get_tags(repo_path: &RepoPath) -> Result<Tags> {
 	let tag_names = repo.tag_names(None)?;
 
 	for name in tag_names.iter().flatten() {
+		let Some(name) = name else { continue };
+
 		let reference = match repo.find_reference(
 			&format!("refs/tags/{name}"),
 		) {
@@ -121,7 +123,8 @@ pub fn get_tags(repo_path: &RepoPath) -> Result<Tags> {
 
 		if let (Some(commit_id), Ok(tag)) = (target, tag) {
 			let name = tag.name().unwrap_or(name).to_string();
-			let annotation = tag.message().map(|s| s.to_string());
+			let annotation =
+				tag.message()?.map(ToString::to_string);
 			adder(commit_id.into(), Tag { name, annotation });
 		} else if let Some(commit_id) = target {
 			adder(commit_id.into(), Tag::new(name));

--- a/asyncgit/src/sync/utils.rs
+++ b/asyncgit/src/sync/utils.rs
@@ -26,6 +26,9 @@ pub struct Head {
 
 ///
 pub fn repo_open_error(repo_path: &RepoPath) -> Option<String> {
+	#[cfg(target_env = "ohos")]
+	super::repository::init_ohos_owner_validation();
+
 	if let Err(e) = Repository::open_ext(
 		repo_path.gitpath(),
 		RepositoryOpenFlags::FROM_ENV,


### PR DESCRIPTION
On OpenHarmony the user/process model is sandbox-based. libgit2's owner validation (`GIT_OPT_SET_OWNER_VALIDATION`) compares file UID with process EUID, which is not applicable and causes spurious "not owned by current user" errors (code=Owner -36).

## Changes

- Disable libgit2 owner validation on OHOS targets (`cfg(target_env = "ohos")`) in both repository-opening entry points
- Use `std::sync::Once` to ensure the init runs exactly once
- Add OpenHarmony cross-compilation instructions to `CONTRIBUTING.md`

## Affected targets

All OHOS targets share `target_env = "ohos"`: `aarch64`, `armv7`, `x86_64`